### PR TITLE
Feat/disable about and privacy policy pages

### DIFF
--- a/f2e/src/components/footer/footer.html
+++ b/f2e/src/components/footer/footer.html
@@ -2,10 +2,12 @@
     <link href="/components/footer/footer.css" rel="stylesheet">
     <div class="container py-4">
         <div class="d-block d-lg-flex align-items-center">
-            <div class="d-flex ms-n3 ms-lg-0 mb-3 mb-lg-0 align-items-center">
+            <!-- <div class="d-flex ms-n3 ms-lg-0 mb-3 mb-lg-0 align-items-center">
+                // TODO :「關於我們」內容寫完後，可以打開
                 <a href="/about/" class="nav-link">關於我們</a>
+                // TODO :「隱私權政策」內容寫完後，可以打開
                 <a href="/privacy-policy/" class="ms-5 nav-link">隱私權政策</a>
-            </div>
+            </div> -->
             <div class="text-white opacity-65 ms-auto">
                 Copyright © 2021 itemhub Inc. All rights reserved.
             </div>

--- a/f2e/src/routing-rule.js
+++ b/f2e/src/routing-rule.js
@@ -1,5 +1,6 @@
 import { APP_CONFIG } from './config.js';
-import { AboutController } from './controllers/about.controller.js';
+// TODO :「隱私權政策」內容寫完後，可以打開，並加上 RoutingRule 相關設定
+// import { AboutController } from './controllers/about.controller.js';
 import { AuthController } from './controllers/auth.controller.js';
 import { CooperationController } from './controllers/cooperation.controller.js';
 import { FeatureController } from './controllers/feature.controller.js';
@@ -8,7 +9,8 @@ import { MainController } from './controllers/main.controller.js';
 import { MasterController } from './controllers/master.controller.js';
 import { MeController } from './controllers/me.controller.js';
 import { PricingController } from './controllers/pricing.controller.js';
-import { PrivacyPolicyController } from './controllers/privacy-policy.controller.js';
+// TODO :「關於我們」內容寫完後，可以打開，並加上 RoutingRule 相關設定
+// import { PrivacyPolicyController } from './controllers/privacy-policy.controller.js';
 import { RootController } from './controllers/root.controller.js';
 import { SignInController } from './controllers/sign-in.controller.js';
 import { SignOutController } from './controllers/sign-out.controller.js';
@@ -124,10 +126,6 @@ export const RoutingRule = [{
                 controller: CooperationController,
                 html: '/template/cooperation.html'
             }, {
-                path: 'privacy-policy/',
-                controller: PrivacyPolicyController,
-                html: '/template/privacy-policy.html'
-            }, {
                 path: 'how/',
                 controller: HowController,
                 html: '/template/how.html'
@@ -135,9 +133,6 @@ export const RoutingRule = [{
                 path: 'feature/',
                 controller: FeatureController,
                 html: '/components/feature/feature.html'
-            }, {
-                path: 'about/',
-                controller: AboutController
             }, {
                 path: 'me/',
                 skipSitemap: true,


### PR DESCRIPTION
# 修改內容

- 將 about / privacy policy 進入的按鈕以及 route disabled，等到頁面寫完後，才會打開。

# 修改專案

- 前台 F2E

# 測試網址和方式

1. 打開 [itemnub](https://dev.itemhub.io/) 開發環境，確認「關於我們」、「隱私權政策」按鈕不存在於 Footer
2. 打開 [itemnub](https://dev.itemhub.io/) 開發環境，about / privacyPolicy route 頁面無法進入

http://g.recordit.co/FEClB1s8yp.gif