### PR TITLE
fix: 加上 Device Pin mode 到 api 上面 (sensor/switch)

### DIFF
--- a/api/Dataservices/DevicePinDataservice.cs
+++ b/api/Dataservices/DevicePinDataservice.cs
@@ -23,7 +23,8 @@ namespace Homo.IotApi
                 .Select(g => new DevicePin()
                 {
                     DeviceId = g.Key.DeviceId,
-                    Pin = g.Key.Pin
+                    Pin = g.Key.Pin,
+                    Mode = DEVICE_MODE.SENSOR
                 })
                 .ToList<DevicePin>();
 
@@ -35,7 +36,8 @@ namespace Homo.IotApi
                 .Select(x => new DevicePin()
                 {
                     DeviceId = x.DeviceId,
-                    Pin = x.Pin
+                    Pin = x.Pin,
+                    Mode = DEVICE_MODE.SWITCH
                 })
                 .ToList<DevicePin>();
 
@@ -48,5 +50,6 @@ namespace Homo.IotApi
     {
         public string Pin { get; set; }
         public long DeviceId { get; set; }
+        public DEVICE_MODE Mode { get; set; }
     }
 }


### PR DESCRIPTION
# 修改內容

- 輸出 pin 資料的時候加上 mode 欄位, 此欄位包含兩個值一個是 0 是 SWITCH, 1 是 SENSOR

# 修改專案

- API

# 測試網址和方式
透過 post man 打以下 API (記得要登入)
https://dev.itemhub.io:5001/api/v1/me/devices/57/pins
檢查格式是否如下
```json
[
    {
        "pin": "D0",
        "deviceId": 57,
        "mode": 1
    }
]
```
