### PR TITLE
feat api: 把 api trigger operators 輸出給 client 使用

### DIFF
--- a/api/Constants/TriggerOperator.cs
+++ b/api/Constants/TriggerOperator.cs
@@ -5,10 +5,15 @@ namespace Homo.IotApi
 {
     public enum TRIGGER_OPERATOR
     {
+        [Description("大於")]
         B,
+        [Description("大於等於")]
         BE,
+        [Description("小於")]
         L,
+        [Description("小於等於")]
         LE,
+        [Description("等於")]
         E
     }
 }

--- a/api/Controllers/UniversalController.cs
+++ b/api/Controllers/UniversalController.cs
@@ -28,5 +28,12 @@ namespace Homo.IotApi
 
             return pricingPlans;
         }
+
+        [HttpGet]
+        [Route("trigger-operators")]
+        public ActionResult<dynamic> getTriggerOperators()
+        {
+            return ConvertHelper.EnumToList(typeof(TRIGGER_OPERATOR));
+        }
     }
 }


### PR DESCRIPTION
# 修改內容

- Ref #249
- as Title 

# 修改專案

- API


# 測試網址和方式
https://localhost:5001/swagger/index.html
IotUniversal Section 試著打開 trigger-operators 用 swagger UI 打這個 api 
<img width="1114" alt="截圖 2022-02-17 下午4 06 14" src="https://user-images.githubusercontent.com/2028693/154432181-b06d198f-5ef9-4edb-b3aa-c5e5795060bd.png">

預期拿到的資料格式長這樣
```json
[
    {
        "key": "B",
        "value": 0,
        "label": "大於"
    },
    {
        "key": "BE",
        "value": 1,
        "label": "大於等於"
    }
]
```