### PR TITLE
feat: 實作重新產生 oAuth Clients 密碼 api

### DIFF
--- a/api/Controllers/MyOauthClientController.cs
+++ b/api/Controllers/MyOauthClientController.cs
@@ -73,6 +73,18 @@ namespace Homo.IotApi
             return new { status = CUSTOM_RESPONSE.OK };
         }
 
+        [HttpPost]
+        [Route("{id}/revoke-secret")]
+        public ActionResult<dynamic> revokeSecret([FromRoute] int id, Homo.AuthApi.DTOs.JwtExtraPayload extraPayload)
+        {
+            long ownerId = extraPayload.Id;
+            string clientSecret = CryptographicHelper.GetSpecificLengthRandomString(64, true, false);
+            string salt = CryptographicHelper.GetSpecificLengthRandomString(128, false, false);
+            string hashClientSecrets = CryptographicHelper.GenerateSaltedHash(clientSecret, salt);
+            OauthClientDataservice.RevokeSecret(_dbContext, ownerId, id, hashClientSecrets, salt);
+            return new { secret = clientSecret };
+        }
+
         [HttpDelete]
         [Route("{id}")]
         public ActionResult<dynamic> delete([FromRoute] long id, Homo.AuthApi.DTOs.JwtExtraPayload extraPayload)

--- a/api/Dataservices/OauthClientDataservice.cs
+++ b/api/Dataservices/OauthClientDataservice.cs
@@ -95,6 +95,15 @@ namespace Homo.IotApi
             dbContext.SaveChanges();
         }
 
+
+        public static void RevokeSecret(IotDbContext dbContext, long ownerId, long id, string hashClientSecrets, string salt)
+        {
+            OauthClient record = dbContext.OauthClient.Where(x => x.Id == id && x.OwnerId == ownerId).FirstOrDefault();
+            record.HashClientSecrets = hashClientSecrets;
+            record.Salt = salt;
+            dbContext.SaveChanges();
+        }
+
         public static void Delete(IotDbContext dbContext, long ownerId, long id)
         {
             OauthClient record = dbContext.OauthClient.Where(x => x.Id == id && x.OwnerId == ownerId).FirstOrDefault();


### PR DESCRIPTION
# 修改內容

- oAuth Clients 是給裝置登入的帳號密碼, 使用者無法修改密碼只能送出重新產生密碼的需求, 避免使用者用太過簡易或是有特殊意義的密碼

# 修改專案

- API

# 測試網址和方式
先登入, 用 postman 打 `/api/v1/oauth-clients/:id/revoke-secrets`  `POST` 看一下回應訊息是否符合以下格式

```json
{
    secret: "...................................."
}
```