### PR TITLE
feat dashboard: oauth clients

### DIFF
--- a/api/Controllers/MyOauthClientController.cs
+++ b/api/Controllers/MyOauthClientController.cs
@@ -73,6 +73,18 @@ namespace Homo.IotApi
             return new { status = CUSTOM_RESPONSE.OK };
         }
 
+        [HttpPost]
+        [Route("{id}/revoke-secret")]
+        public ActionResult<dynamic> revokeSecret([FromRoute] int id, Homo.AuthApi.DTOs.JwtExtraPayload extraPayload)
+        {
+            long ownerId = extraPayload.Id;
+            string clientSecret = CryptographicHelper.GetSpecificLengthRandomString(64, true, false);
+            string salt = CryptographicHelper.GetSpecificLengthRandomString(128, false, false);
+            string hashClientSecrets = CryptographicHelper.GenerateSaltedHash(clientSecret, salt);
+            OauthClientDataservice.RevokeSecret(_dbContext, ownerId, id, hashClientSecrets, salt);
+            return new { secret = clientSecret };
+        }
+
         [HttpDelete]
         [Route("{id}")]
         public ActionResult<dynamic> delete([FromRoute] long id, Homo.AuthApi.DTOs.JwtExtraPayload extraPayload)

--- a/api/Dataservices/OauthClientDataservice.cs
+++ b/api/Dataservices/OauthClientDataservice.cs
@@ -95,6 +95,15 @@ namespace Homo.IotApi
             dbContext.SaveChanges();
         }
 
+
+        public static void RevokeSecret(IotDbContext dbContext, long ownerId, long id, string hashClientSecrets, string salt)
+        {
+            OauthClient record = dbContext.OauthClient.Where(x => x.Id == id && x.OwnerId == ownerId).FirstOrDefault();
+            record.HashClientSecrets = hashClientSecrets;
+            record.Salt = salt;
+            dbContext.SaveChanges();
+        }
+
         public static void Delete(IotDbContext dbContext, long ownerId, long id)
         {
             OauthClient record = dbContext.OauthClient.Where(x => x.Id == id && x.OwnerId == ownerId).FirstOrDefault();

--- a/dashboard/src/components/pagination/pagination.module.scss
+++ b/dashboard/src/components/pagination/pagination.module.scss
@@ -1,0 +1,2 @@
+.pagination {
+}

--- a/dashboard/src/components/pagination/pagination.stories.tsx
+++ b/dashboard/src/components/pagination/pagination.stories.tsx
@@ -1,0 +1,12 @@
+/* eslint-disable */
+import Pagination from './pagination';
+
+export default {
+    title: 'pagination'
+};
+
+export const Default = () => <Pagination />;
+
+Default.story = {
+    name: 'default'
+};

--- a/dashboard/src/components/pagination/pagination.stories.tsx
+++ b/dashboard/src/components/pagination/pagination.stories.tsx
@@ -2,11 +2,11 @@
 import Pagination from './pagination';
 
 export default {
-    title: 'pagination'
+    title: 'pagination',
 };
 
 export const Default = () => <Pagination />;
 
 Default.story = {
-    name: 'default'
+    name: 'default',
 };

--- a/dashboard/src/components/pagination/pagination.test.tsx
+++ b/dashboard/src/components/pagination/pagination.test.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import Pagination from './pagination';
+
+describe('<Pagination />', () => {
+    test('it should mount', () => {
+        render(<Pagination />);
+
+        const pagination = screen.getByTestId('Pagination');
+
+        expect(pagination).toBeInTheDocument();
+    });
+});

--- a/dashboard/src/components/pagination/pagination.tsx
+++ b/dashboard/src/components/pagination/pagination.tsx
@@ -1,0 +1,39 @@
+import styles from './pagination.module.scss';
+import { useState, useEffect } from 'react';
+import { Link } from 'react-router-dom';
+
+const Pagination = (props: any | undefined) => {
+    const [pages, setPages] = useState<Array<number>>([]);
+    const { rowNums, limit, page } = props;
+
+    useEffect(() => {
+        const maxPage = Math.ceil(rowNums / limit);
+        const _pages = [];
+        for (let i = 1; i <= maxPage; i++) {
+            _pages.push(i);
+        }
+        setPages(_pages);
+    }, [rowNums, limit]);
+
+    return (
+        <div className={styles.pagination} data-testid="pagination">
+            {pages.map((pageNumber) =>
+                pageNumber === page ? (
+                    <span key={pageNumber} className="p-2">
+                        {pageNumber}
+                    </span>
+                ) : (
+                    <Link
+                        className="p-2"
+                        to={`./?page=${pageNumber}`}
+                        key={pageNumber}
+                    >
+                        {pageNumber}
+                    </Link>
+                )
+            )}
+        </div>
+    );
+};
+
+export default Pagination;

--- a/dashboard/src/constants/api.ts
+++ b/dashboard/src/constants/api.ts
@@ -6,6 +6,9 @@ export const END_POINT = {
     DEVICES: 'me/devices',
     DEVICE: 'me/devices/:id',
     DEVICE_PINS: 'me/devices/:id/pins',
+    OAUTH_CLIENTS: 'me/oauth-clients',
+    OAUTH_CLIENT: 'me/oauth-clients/:id',
+    OAUTH_CLIENT_REVOKE_SECRET: 'me/oauth-clients/:id/revoke-secret',
 };
 
 export const HTTP_METHOD = {

--- a/dashboard/src/dataservices/devices.dataservice.ts
+++ b/dashboard/src/dataservices/devices.dataservice.ts
@@ -7,9 +7,8 @@ import {
     GetDevicesParams,
     GetSingleDeviceParams,
     UpdateSingleDeviceParams,
-    GetDevicePinsParams
+    GetDevicePinsParams,
 } from '@/types/dataservices.type';
-
 
 export const DevicesDataservices = {
     GetList: async ({ page, limit }: GetDevicesParams) => {

--- a/dashboard/src/helpers/api.helper.ts
+++ b/dashboard/src/helpers/api.helper.ts
@@ -36,14 +36,14 @@ export const ApiHelpers = {
     }: SendRequestParams<T>) => {
         const fetchOption = payload
             ? {
-                method: method,
-                headers,
-                body: JSON.stringify(payload),
-            }
+                  method: method,
+                  headers,
+                  body: JSON.stringify(payload),
+              }
             : {
-                method: method,
-                headers,
-            };
+                  method: method,
+                  headers,
+              };
 
         // eslint-disable-next-line no-async-promise-executor
         return new Promise<FetchResult<T>>(async (resolve, reject) => {
@@ -104,9 +104,9 @@ export const ApiHelpers = {
         const headers = shouldDeleteContentType
             ? fetchOption.headers
             : {
-                'Content-Type': 'application/json',
-                ...fetchOption.headers,
-            };
+                  'Content-Type': 'application/json',
+                  ...fetchOption.headers,
+              };
 
         if (
             fetchOption.body &&

--- a/dashboard/src/helpers/cookie.helper.ts
+++ b/dashboard/src/helpers/cookie.helper.ts
@@ -1,4 +1,4 @@
-import { SetCookieParams } from '@/types/helpers.type'
+import { SetCookieParams } from '@/types/helpers.type';
 
 export const CookieHelpers = {
     SetCookie: ({ name, value, days }: SetCookieParams) => {

--- a/dashboard/src/hooks/apis/oauth-clients.hook.ts
+++ b/dashboard/src/hooks/apis/oauth-clients.hook.ts
@@ -1,0 +1,178 @@
+import { useCallback } from 'react';
+import { useAppDispatch } from '@/hooks/redux.hook';
+import { useFetchApi } from '@/hooks/apis/fetch.hook';
+import { oauthClientsActions } from '@/redux/reducers/oauth-clients.reducer';
+import {
+    API_URL,
+    END_POINT,
+    HTTP_METHOD,
+    RESPONSE_STATUS,
+} from '@/constants/api';
+import { ApiHelpers } from '@/helpers/api.helper';
+
+export const useGetOauthClients = ({
+    page,
+    limit,
+}: {
+    page: number;
+    limit: number;
+}) => {
+    const fetchMethod = useCallback(async () => {
+        const apiPath = `${API_URL}${END_POINT.OAUTH_CLIENTS}?page=${page}&limit=${limit}`;
+        const result = await ApiHelpers.SendRequestWithToken<any>({
+            apiPath,
+            method: HTTP_METHOD.GET,
+        });
+        return result.data;
+    }, [page, limit]);
+
+    const dispatch = useAppDispatch();
+    const dispatchRefresh = useCallback(
+        (data: any) => {
+            if (data) {
+                dispatch(oauthClientsActions.refresh(data.oauthClients));
+            }
+        },
+        [dispatch]
+    );
+
+    return useFetchApi<any>({
+        initialData: null,
+        fetchMethod,
+        callbackFunc: dispatchRefresh,
+    });
+};
+
+export const useGetOauthClient = (id: number) => {
+    const fetchMethod = useCallback(async () => {
+        let apiPath = `${API_URL}${END_POINT.OAUTH_CLIENT}`;
+        apiPath = apiPath.replace(':id', id.toString());
+        const result = await ApiHelpers.SendRequestWithToken<any>({
+            apiPath,
+            method: HTTP_METHOD.GET,
+        });
+        return result.data;
+    }, [id]);
+
+    const dispatch = useAppDispatch();
+    const dispatchRefresh = useCallback(
+        (data: any) => {
+            if (data) {
+                dispatch(oauthClientsActions.refreshOne(data));
+            }
+        },
+        [dispatch]
+    );
+
+    return useFetchApi<any>({
+        initialData: null,
+        fetchMethod,
+        callbackFunc: dispatchRefresh,
+    });
+};
+
+export const useUpdateOauthClient = ({
+    id,
+    clientId,
+}: {
+    id: number;
+    clientId: string;
+}) => {
+    const fetchMethod = useCallback(async () => {
+        let apiPath = `${API_URL}${END_POINT.OAUTH_CLIENT}`;
+        apiPath = apiPath.replace(':id', id.toString());
+        const result = await ApiHelpers.SendRequestWithToken<any>({
+            apiPath,
+            method: HTTP_METHOD.PATCH,
+            payload: {
+                clientId,
+            },
+        });
+        return result.data;
+    }, [id, clientId]);
+
+    const dispatch = useAppDispatch();
+    const dispatchRefresh = useCallback(
+        (data: any) => {
+            if (data.status === RESPONSE_STATUS.OK) {
+                dispatch(
+                    oauthClientsActions.updateOne({
+                        clientId,
+                        id,
+                    })
+                );
+            }
+        },
+        [clientId, id, dispatch]
+    );
+
+    return useFetchApi<any>({
+        initialData: null,
+        fetchMethod,
+        callbackFunc: dispatchRefresh,
+    });
+};
+
+export const useRevokeSecretOauthClient = (id: number) => {
+    const fetchMethod = useCallback(async () => {
+        let apiPath = `${API_URL}${END_POINT.OAUTH_CLIENT_REVOKE_SECRET}`;
+        apiPath = apiPath.replace(':id', id.toString());
+        const result = await ApiHelpers.SendRequestWithToken<any>({
+            apiPath,
+            method: HTTP_METHOD.POST,
+        });
+        return result.data;
+    }, [id]);
+
+    const dispatch = useAppDispatch();
+    const dispatchRefresh = useCallback(
+        (data: any) => {
+            if (data.status === RESPONSE_STATUS.OK) {
+                dispatch(
+                    oauthClientsActions.updateOne({
+                        id,
+                    })
+                );
+            }
+        },
+        [id, dispatch]
+    );
+
+    return useFetchApi<any>({
+        initialData: null,
+        fetchMethod,
+        callbackFunc: dispatchRefresh,
+    });
+};
+
+export const useDeleteOauthClients = (ids: number[]) => {
+    const fetchMethod = useCallback(async () => {
+        const apiPath = `${API_URL}${END_POINT.OAUTH_CLIENTS}`;
+        const result = await ApiHelpers.SendRequestWithToken<any>({
+            apiPath,
+            method: HTTP_METHOD.DELETE,
+            payload: ids,
+        });
+        return result.data;
+    }, [ids]);
+
+    const dispatch = useAppDispatch();
+    const dispatchRefresh = useCallback(
+        (data: any) => {
+            if (data.status === RESPONSE_STATUS.OK) {
+                dispatch(
+                    oauthClientsActions.deleteMultiple({
+                        ids,
+                    })
+                );
+            }
+        },
+        [ids, dispatch]
+    );
+
+    return useFetchApi<any>({
+        initialData: null,
+        fetchMethod,
+        callbackFunc: dispatchRefresh,
+    });
+};

--- a/dashboard/src/index.tsx
+++ b/dashboard/src/index.tsx
@@ -12,6 +12,7 @@ import Trigger from './pages/trigger/trigger';
 import OauthClients from './pages/oauth-clients/oauth-clients';
 import { Provider } from 'react-redux';
 import store from './redux/store';
+import OauthClient from './pages/oauth-client/oauth-client';
 
 ReactDOM.render(
     <BrowserRouter>
@@ -34,6 +35,7 @@ ReactDOM.render(
                     <Route path="triggers" element={<Triggers />} />
                     <Route path="triggers/:id" element={<Trigger />} />
                     <Route path="oauth-clients" element={<OauthClients />} />
+                    <Route path="oauth-clients/:id" element={<OauthClient />} />
                 </Route>
                 <Route path="/404" element={<NotFound />} />
             </Route>

--- a/dashboard/src/pages/oauth-client/oauth-client.module.scss
+++ b/dashboard/src/pages/oauth-client/oauth-client.module.scss
@@ -1,0 +1,2 @@
+.oauth-client {
+}

--- a/dashboard/src/pages/oauth-client/oauth-client.stories.tsx
+++ b/dashboard/src/pages/oauth-client/oauth-client.stories.tsx
@@ -1,0 +1,12 @@
+/* eslint-disable */
+import OauthClient from './oauth-client';
+
+export default {
+    title: 'OauthClient',
+};
+
+export const Default = () => <OauthClient />;
+
+Default.story = {
+    name: 'default',
+};

--- a/dashboard/src/pages/oauth-client/oauth-client.test.tsx
+++ b/dashboard/src/pages/oauth-client/oauth-client.test.tsx
@@ -1,0 +1,13 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import OauthClient from './oauth-client';
+
+describe('<OauthClient />', () => {
+    test('it should mount', () => {
+        render(<OauthClient />);
+
+        const oauthClient = screen.getByTestId('OauthClient');
+
+        expect(oauthClient).toBeInTheDocument();
+    });
+});

--- a/dashboard/src/pages/oauth-client/oauth-client.tsx
+++ b/dashboard/src/pages/oauth-client/oauth-client.tsx
@@ -1,0 +1,97 @@
+import styles from './oauth-client.module.scss';
+import { useEffect, useState } from 'react';
+import { useAppSelector } from '@/hooks/redux.hook';
+import {
+    useGetOauthClient,
+    useRevokeSecretOauthClient,
+} from '@/hooks/apis/oauth-clients.hook';
+import { selectOauthClients } from '../../redux/reducers/oauth-clients.reducer';
+import { useNavigate, useParams } from 'react-router-dom';
+import {
+    useUpdateOauthClient,
+    useDeleteOauthClients,
+} from '../../hooks/apis/oauth-clients.hook';
+import { RESPONSE_STATUS } from '@/constants/api';
+
+const OauthClient = () => {
+    const { id } = useParams();
+    const navigate = useNavigate();
+
+    const list = useAppSelector(selectOauthClients);
+
+    const oauthClient = (list || []).filter(
+        (item) => item.id === Number(id)
+    )[0];
+
+    const [clientId, setClientId] = useState(oauthClient?.clientId);
+
+    // api hook
+    const { isLoading, fetchApi } = useGetOauthClient(Number(id));
+    const { fetchApi: updateApi, isLoading: isUpdating } = useUpdateOauthClient(
+        { id: Number(id), clientId }
+    );
+    const {
+        fetchApi: revokeSecretApi,
+        isLoading: isRevoking,
+        data: revokeSecretResponse,
+    } = useRevokeSecretOauthClient(Number(id));
+
+    const {
+        fetchApi: deleteMultipleApi,
+        isLoading: isDeleting,
+        data: deleteOAuthClientResponse,
+    } = useDeleteOauthClients([Number(id)]);
+
+    useEffect(() => {
+        if (oauthClient) {
+            return;
+        }
+        fetchApi();
+    }, [fetchApi, oauthClient, id]);
+
+    useEffect(() => {
+        setClientId(oauthClient?.clientId);
+    }, [oauthClient]);
+
+    useEffect(() => {
+        if (deleteOAuthClientResponse?.status === RESPONSE_STATUS.OK) {
+            navigate('../oauth-clients', { replace: true });
+        }
+    }, [navigate, deleteOAuthClientResponse]);
+
+    return (
+        <div className={styles.OauthClient} data-testid="oauth-client">
+            {isLoading || list === null ? (
+                <div>Loading</div>
+            ) : (
+                <div>
+                    <div>{oauthClient.id}</div>
+                    <input
+                        type="text"
+                        className="form-control"
+                        value={clientId}
+                        onChange={(e) => setClientId(e.target.value)}
+                    />
+                    <input
+                        type="text"
+                        className="form-control"
+                        placeholder="****************************"
+                        value={revokeSecretResponse?.secret}
+                        disabled
+                    />
+                    <button disabled={isDeleting} onClick={deleteMultipleApi}>
+                        {isDeleting ? 'Deleting' : 'Delete'}
+                    </button>
+                    <button disabled={isUpdating} onClick={updateApi}>
+                        {isUpdating ? 'Updating' : 'Update'}
+                    </button>
+                    <button disabled={isRevoking} onClick={revokeSecretApi}>
+                        {isRevoking ? 'Revoking' : 'Revoke Client Secret'}
+                    </button>
+                </div>
+            )}
+        </div>
+    );
+};
+
+export default OauthClient;

--- a/dashboard/src/pages/oauth-clients/oauth-clients.module.scss
+++ b/dashboard/src/pages/oauth-clients/oauth-clients.module.scss
@@ -1,2 +1,2 @@
-.OauthClients {
+.oauth-clients {
 }

--- a/dashboard/src/pages/oauth-clients/oauth-clients.tsx
+++ b/dashboard/src/pages/oauth-clients/oauth-clients.tsx
@@ -1,9 +1,98 @@
 import styles from './oauth-clients.module.scss';
+import { useEffect, useState } from 'react';
+import { useQuery } from '@/hooks/query.hook';
+import { Link, useNavigate } from 'react-router-dom';
+import { useAppSelector } from '@/hooks/redux.hook';
+import {
+    useDeleteOauthClients,
+    useGetOauthClients,
+} from '@/hooks/apis/oauth-clients.hook';
+import { selectOauthClients } from '../../redux/reducers/oauth-clients.reducer';
+import Pagination from '@/components/pagination/pagination';
+import { RESPONSE_STATUS } from '@/constants/api';
 
-const OauthClients = () => (
-    <div className={styles.OauthClients} data-testid="OauthClients">
-        OauthClients Component
-    </div>
-);
+const OauthClients = () => {
+    const query = useQuery();
+    const limit = Number(query.get('limit') || 5);
+    const [page, setPage] = useState(Number(query.get('page') || 1));
+    const list = useAppSelector(selectOauthClients);
+    const [rowNums, setRowNums] = useState(0);
+    const { isLoading, fetchApi, data } = useGetOauthClients({ page, limit });
+    const [selectedIds, setSelectedIds] = useState(Array<number>());
+    const [refreshFlag, setRefreshFlag] = useState(false);
+
+    const {
+        isLoading: isDeleting,
+        fetchApi: deleteMultipleApi,
+        data: responseOfDelete,
+    } = useDeleteOauthClients(selectedIds);
+
+    useEffect(() => {
+        setPage(Number(query.get('page') || 1));
+    }, [query.get('page')]);
+
+    useEffect(() => {
+        fetchApi();
+    }, [page, refreshFlag]);
+
+    useEffect(() => {
+        setRowNums(data?.rowNums);
+    }, [data]);
+
+    useEffect(() => {
+        if (responseOfDelete?.status === RESPONSE_STATUS.OK) {
+            setRefreshFlag(!refreshFlag);
+        }
+    }, [responseOfDelete]);
+
+    const check = (event: any) => {
+        const _selectedIds = [...selectedIds];
+        if (event.target.checked) {
+            _selectedIds.push(Number(event.target.value));
+        } else {
+            const index = _selectedIds.findIndex(
+                (item) => item === Number(event.target.value)
+            );
+            _selectedIds.splice(index, 1);
+        }
+        setSelectedIds(_selectedIds);
+    };
+
+    return (
+        <div className={styles.OauthClients} data-testid="oauth-clients">
+            <div>
+                <button
+                    onClick={deleteMultipleApi}
+                    disabled={isDeleting || selectedIds.length <= 0}
+                >
+                    {isDeleting ? 'Deleting' : 'Delete Selected Row'}
+                </button>
+            </div>
+
+            {isLoading || list === null ? (
+                <div>Loading</div>
+            ) : (
+                list.map(({ id, clientId }) => (
+                    <label className="d-flex align-items-top" key={id}>
+                        <input type="checkbox" onChange={check} value={id} />
+                        <div>
+                            <div>
+                                <span>Id</span>
+                                <span>ClientId</span>
+                            </div>
+                            <Link to={`/dashboard/oauth-clients/${id}`}>
+                                <span>{id}</span>
+                                <span>{clientId}</span>
+                            </Link>
+                        </div>
+                    </label>
+                ))
+            )}
+            <div>Page: {page}</div>
+            <Pagination rowNums={rowNums} page={page} limit={limit} />
+            <button onClick={fetchApi}>refresh oauth clients list</button>
+        </div>
+    );
+};
 
 export default OauthClients;

--- a/dashboard/src/redux/reducers/oauth-clients.reducer.ts
+++ b/dashboard/src/redux/reducers/oauth-clients.reducer.ts
@@ -1,0 +1,82 @@
+import { createSelector, createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { RootState } from '@/redux/store';
+import { OauthClient } from '@/types/oauth-clients.type';
+
+export const oauthClientsSlice = createSlice({
+    name: 'oauth-clients',
+    initialState: null as OauthClient[] | null,
+    reducers: {
+        refresh: (state, action: PayloadAction<OauthClient[]>) => {
+            const list = action.payload;
+            return list;
+        },
+        refreshOne: (state, action: PayloadAction<OauthClient>) => {
+            const list = state;
+            const newOne = action.payload;
+
+            if (list === null) {
+                return [newOne];
+            }
+
+            const targetIndex = list.findIndex(
+                (oldOne) => oldOne.id === newOne.id
+            );
+            list[targetIndex] = {
+                ...newOne,
+            };
+            return list;
+        },
+        updateOne: (state, action: PayloadAction<Partial<OauthClient>>) => {
+            const list = state;
+            const newOne = action.payload;
+
+            if (list === null) {
+                throw new Error(
+                    'Can not updateOne when oauth-clients is null.'
+                );
+            }
+
+            const targetIndex = list.findIndex(({ id }) => id === newOne.id);
+            list[targetIndex] = {
+                ...list[targetIndex],
+                ...newOne,
+            };
+
+            return list;
+        },
+        addOne: (state, action: PayloadAction<Partial<OauthClient>>) => {
+            const list = state;
+            const newOne = action.payload;
+
+            if (list === null) {
+                throw new Error('Can not addOne when oauth-clients is null.');
+            }
+
+            const targetIndex = list.findIndex(({ id }) => id === newOne.id);
+            list[targetIndex] = {
+                ...list[targetIndex],
+                ...newOne,
+            };
+
+            return list;
+        },
+        deleteMultiple: (state, action: PayloadAction<{ ids: number[] }>) => {
+            const list = state;
+            const deletePayload = action.payload;
+
+            if (list === null) {
+                throw new Error('Can not delete when oauth-clients is null.');
+            }
+
+            return list.filter(
+                (item) => deletePayload.ids.indexOf(item.id) !== -1
+            );
+        },
+    },
+});
+
+export const oauthClientsActions = oauthClientsSlice.actions;
+
+export const selectOauthClients = (state: RootState) => state.oauthClients;
+
+export default oauthClientsSlice.reducer;

--- a/dashboard/src/redux/store.ts
+++ b/dashboard/src/redux/store.ts
@@ -1,9 +1,11 @@
 import { configureStore } from '@reduxjs/toolkit';
 import devicesReducer from './reducers/devices.reducer';
+import oauthClientsReducer from './reducers/oauth-clients.reducer';
 
 const store = configureStore({
     reducer: {
         devices: devicesReducer,
+        oauthClients: oauthClientsReducer,
     },
 });
 

--- a/dashboard/src/types/dataservices.type.ts
+++ b/dashboard/src/types/dataservices.type.ts
@@ -31,6 +31,3 @@ export interface SignWithEmailParams {
     email: string;
     password: string;
 }
-
-
-

--- a/dashboard/src/types/helpers.type.ts
+++ b/dashboard/src/types/helpers.type.ts
@@ -21,7 +21,7 @@ export type FetchResult<T> = {
     httpStatus: number;
     status: string;
     data: T;
-}
+};
 
 export interface FetchErrorResultData {
     errorKey: string;

--- a/dashboard/src/types/oauth-clients.type.ts
+++ b/dashboard/src/types/oauth-clients.type.ts
@@ -1,0 +1,7 @@
+export interface OauthClient {
+    id: number;
+    name: string;
+    ownerId: number;
+    clientId: string;
+    hashClientSecrets: string;
+}


### PR DESCRIPTION
# 修改內容

- 實作 dashboard pagination component
- 實作 oauth clients crud

# 修改專案

- Dashboard F2E

# 測試網址和方式

http://localhost:3000/dashboard/oauth-clients

- 具有分頁的 oauth-client 列表
- 列表上可以做批次勾選刪除
- 列表頁具有連結可以連到單一資料頁面
- 單一資料頁可以更改 client id 
- 單一資料頁面可以重新產生 secret 
- 單一資料頁面可以刪除資料並倒回列表夜