### PR TITLE
fix: 修正 opener.gtag  呼叫造成  error, gtag 應該是定義在 opener.window 上

### DIFF
--- a/website/src/controllers/oauth.controller.js
+++ b/website/src/controllers/oauth.controller.js
@@ -39,7 +39,7 @@ export class OauthController extends RoutingController {
 
         CookieUtil.setCookie('token', resp.data.token);
         opener.history.pushState({}, '', '/?tf=' + new Date().getUTCMilliseconds());
-        opener.gtag('event', EVENTS.SIGN_IN);
+        opener.window.gtag('event', EVENTS.SIGN_IN);
         window.close();
     }
 


### PR DESCRIPTION
# 修改內容

- 如標題

# 修改專案

- Website F2E

# 測試網址和方式
在 local 端測試看一下彈出的 oAuth window 是否會被關掉還是會卡在那邊跳出一個錯誤訊息, 正常情況會自動關掉視窗 