### PR TITLE
Feat: implement simple triggers / triger page

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 目前總共有兩個專案項目，分別為：
 
-- Dashboard : 後台系統，前端位於 dashboard 資料夾中，API 端位於 api 資料夾中。
-- Website : 前台官網，前端位於 website 資料夾中，API 端位於 api 資料夾中。
+- Website : 前台官網，前端位於 [website 資料夾](./website)中，API 端位於 [api 資料夾](./api)中。
+- Dashboard : 後台系統，前端位於 [dashboard 資料夾](./dashboard)中，API 端位於 [api 資料夾](./api)中。
 
 各個專案項目的說明，請參見各自資料夾中的 README。
 

--- a/api/Controllers/MyDeviceController.cs
+++ b/api/Controllers/MyDeviceController.cs
@@ -34,7 +34,7 @@ namespace Homo.IotApi
             return new
             {
                 devices = records,
-                rowNums = DeviceDataservice.GetRowNum(_dbContext, ownerId)
+                rowNum = DeviceDataservice.GetRowNum(_dbContext, ownerId)
             };
         }
 

--- a/api/Controllers/MyOauthClientController.cs
+++ b/api/Controllers/MyOauthClientController.cs
@@ -25,7 +25,7 @@ namespace Homo.IotApi
             return new
             {
                 oauthClients = records,
-                rowNums = OauthClientDataservice.GetRowNum(_dbContext, ownerId)
+                rowNum = OauthClientDataservice.GetRowNum(_dbContext, ownerId)
             };
         }
 

--- a/api/Controllers/MyOauthClientRedirectUriController.cs
+++ b/api/Controllers/MyOauthClientRedirectUriController.cs
@@ -23,7 +23,7 @@ namespace Homo.IotApi
             return new
             {
                 oauthClientRedirectUris = records,
-                rowNums = OauthClientRedirectUriDataservice.GetRowNum(_dbContext, extraPayload.Id)
+                rowNum = OauthClientRedirectUriDataservice.GetRowNum(_dbContext, extraPayload.Id)
             };
         }
 

--- a/api/Controllers/MyTriggerController.cs
+++ b/api/Controllers/MyTriggerController.cs
@@ -35,8 +35,8 @@ namespace Homo.IotApi
         {
             return new
             {
-                paginationData = TriggerDataservice.GetList(_dbContext, page, limit, extraPayload.Id, sourceDeviceId, sourcePin, sourceDeviceName, destinationDeviceId, destinationPin, destinationDeviceName),
-                rowNum = TriggerDataservice.GetRowNum(_dbContext, extraPayload.Id, sourceDeviceId, sourcePin, sourceDeviceName, destinationDeviceId, destinationPin, destinationDeviceName)
+                triggers = TriggerDataservice.GetList(_dbContext, page, limit, extraPayload.Id, sourceDeviceId, sourcePin, sourceDeviceName, destinationDeviceId, destinationPin, destinationDeviceName),
+                rowNums = TriggerDataservice.GetRowNum(_dbContext, extraPayload.Id, sourceDeviceId, sourcePin, sourceDeviceName, destinationDeviceId, destinationPin, destinationDeviceName)
             };
         }
 

--- a/api/Controllers/MyTriggerController.cs
+++ b/api/Controllers/MyTriggerController.cs
@@ -36,7 +36,7 @@ namespace Homo.IotApi
             return new
             {
                 triggers = TriggerDataservice.GetList(_dbContext, page, limit, extraPayload.Id, sourceDeviceId, sourcePin, sourceDeviceName, destinationDeviceId, destinationPin, destinationDeviceName),
-                rowNums = TriggerDataservice.GetRowNum(_dbContext, extraPayload.Id, sourceDeviceId, sourcePin, sourceDeviceName, destinationDeviceId, destinationPin, destinationDeviceName)
+                rowNum = TriggerDataservice.GetRowNum(_dbContext, extraPayload.Id, sourceDeviceId, sourcePin, sourceDeviceName, destinationDeviceId, destinationPin, destinationDeviceName)
             };
         }
 

--- a/api/Controllers/MyZoneController.cs
+++ b/api/Controllers/MyZoneController.cs
@@ -23,7 +23,7 @@ namespace Homo.IotApi
             return new
             {
                 zones = records,
-                rowNums = ZoneDataservice.GetRowNum(_dbContext, extraPayload.Id)
+                rowNum = ZoneDataservice.GetRowNum(_dbContext, extraPayload.Id)
             };
         }
 

--- a/api/Controllers/UserController.cs
+++ b/api/Controllers/UserController.cs
@@ -18,7 +18,7 @@ namespace Homo.IotApi
         [Route("number-of-registered-users")]
         public ActionResult<dynamic> getNumberOfRegisteredUsers()
         {
-            return new { nums = UserDataservice.GetRowNums(_dbContext, null, null) };
+            return new { nums = UserDataservice.GetRowNum(_dbContext, null, null) };
         }
 
         [HttpPost]

--- a/api/Homo.AuthApi/Controllers/GroupController.cs
+++ b/api/Homo.AuthApi/Controllers/GroupController.cs
@@ -21,7 +21,7 @@ namespace Homo.AuthApi
             return new
             {
                 groups = records,
-                rowNums = GroupDataservice.GetRowNum(_dbContext, name)
+                rowNum = GroupDataservice.GetRowNum(_dbContext, name)
             };
         }
 

--- a/api/Homo.AuthApi/Controllers/UserController.cs
+++ b/api/Homo.AuthApi/Controllers/UserController.cs
@@ -29,7 +29,7 @@ namespace Homo.AuthApi
             return new
             {
                 users = records,
-                rowNums = UserDataservice.GetRowNums(_dbContext, email, userIds)
+                rowNum = UserDataservice.GetRowNum(_dbContext, email, userIds)
             };
         }
 

--- a/api/Homo.AuthApi/Dataservices/UserDataservice.cs
+++ b/api/Homo.AuthApi/Dataservices/UserDataservice.cs
@@ -22,7 +22,7 @@ namespace Homo.AuthApi
                 .ToList();
         }
 
-        public static int GetRowNums(DBContext dbContext, string email, List<long> userIds)
+        public static int GetRowNum(DBContext dbContext, string email, List<long> userIds)
         {
             return dbContext.User
                 .Where(

--- a/api/Homo.AuthApi/tools/auto-generator/template/controller.cs.template
+++ b/api/Homo.AuthApi/tools/auto-generator/template/controller.cs.template
@@ -23,7 +23,7 @@ namespace {namespace}
             return new
             {
                 {firstLowerCamelCaseModelsName} = records,
-                rowNums = {firstUpperCamelCaseModelName}Dataservice.GetRowNum(_dbContext)
+                rowNum = {firstUpperCamelCaseModelName}Dataservice.GetRowNum(_dbContext)
             };
         }
 

--- a/dashboard/src/components/pagination/pagination.tsx
+++ b/dashboard/src/components/pagination/pagination.tsx
@@ -2,22 +2,18 @@ import styles from './pagination.module.scss';
 import { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 
-const Pagination = (props: {
-    rowNums: number;
-    limit: number;
-    page: number;
-}) => {
+const Pagination = (props: { rowNum: number; limit: number; page: number }) => {
     const [pages, setPages] = useState<Array<number>>([]);
-    const { rowNums, limit, page } = props;
+    const { rowNum, limit, page } = props;
 
     useEffect(() => {
-        const maxPage = Math.ceil(rowNums / limit);
+        const maxPage = Math.ceil(rowNum / limit);
         const pages = [];
         for (let i = 1; i <= maxPage; i++) {
             pages.push(i);
         }
         setPages(pages);
-    }, [rowNums, limit]);
+    }, [rowNum, limit]);
 
     return (
         <div className={styles.pagination} data-testid="pagination">

--- a/dashboard/src/constants/api.ts
+++ b/dashboard/src/constants/api.ts
@@ -9,6 +9,8 @@ export const END_POINT = {
     OAUTH_CLIENTS: 'me/oauth-clients',
     OAUTH_CLIENT: 'me/oauth-clients/:id',
     OAUTH_CLIENT_REVOKE_SECRET: 'me/oauth-clients/:id/revoke-secret',
+    TRIGGERS: 'me/triggers',
+    TRIGGER: 'me/triggers/:id',
 };
 
 export const HTTP_METHOD = {

--- a/dashboard/src/dataservices/devices.dataservice.ts
+++ b/dashboard/src/dataservices/devices.dataservice.ts
@@ -3,10 +3,10 @@ import { ApiHelpers } from '@/helpers/api.helper';
 import { DeviceItem, PinItem } from '@/types/devices.type';
 import {
     GetDevicesResponseData,
-    UpdateSingleDeviceResponseData,
+    UpdateDeviceResponseData,
     GetDevicesParams,
-    GetSingleDeviceParams,
-    UpdateSingleDeviceParams,
+    GetDeviceParams,
+    UpdateDeviceParams,
     GetDevicePinsParams,
 } from '@/types/dataservices.type';
 
@@ -21,7 +21,7 @@ export const DevicesDataservices = {
             });
         return result.data;
     },
-    GetOne: async ({ id }: GetSingleDeviceParams) => {
+    GetOne: async ({ id }: GetDeviceParams) => {
         let apiPath = `${API_URL}${END_POINT.DEVICE}`;
         apiPath = apiPath.replace(':id', id.toString());
 
@@ -31,18 +31,16 @@ export const DevicesDataservices = {
         });
         return result.data;
     },
-    UpdateOne: async ({ id, editedData }: UpdateSingleDeviceParams) => {
+    UpdateOne: async ({ id, editedData }: UpdateDeviceParams) => {
         let apiPath = `${API_URL}${END_POINT.DEVICE}`;
         apiPath = apiPath.replace(':id', id.toString());
 
         const result =
-            await ApiHelpers.SendRequestWithToken<UpdateSingleDeviceResponseData>(
-                {
-                    apiPath,
-                    method: HTTP_METHOD.PATCH,
-                    payload: editedData,
-                }
-            );
+            await ApiHelpers.SendRequestWithToken<UpdateDeviceResponseData>({
+                apiPath,
+                method: HTTP_METHOD.PATCH,
+                payload: editedData,
+            });
         return result.data;
     },
     GetOnePins: async ({ id }: GetDevicePinsParams) => {

--- a/dashboard/src/hooks/apis/devices.hook.ts
+++ b/dashboard/src/hooks/apis/devices.hook.ts
@@ -98,7 +98,7 @@ export const useUpdateDeviceApi = ({ id, editedData }: UpdateDeviceParams) => {
     return {
         isLoading,
         error,
-        updateSingleDeviceApi: fetchApi,
+        updateDeviceApi: fetchApi,
     };
 };
 

--- a/dashboard/src/hooks/apis/devices.hook.ts
+++ b/dashboard/src/hooks/apis/devices.hook.ts
@@ -7,9 +7,9 @@ import { DeviceItem, PinItem } from '@/types/devices.type';
 import {
     GetDevicesParams,
     GetDevicesResponseData,
-    GetSingleDeviceParams,
-    UpdateSingleDeviceParams,
-    UpdateSingleDeviceResponseData,
+    GetDeviceParams,
+    UpdateDeviceParams,
+    UpdateDeviceResponseData,
     GetDevicePinsParams,
 } from '@/types/dataservices.type';
 import { RESPONSE_STATUS } from '@/constants/api';
@@ -42,37 +42,34 @@ export const useGetDevicesApi = ({ page, limit }: GetDevicesParams) => {
     };
 };
 
-export const useGetSingleDeviceApi = ({ id }: GetSingleDeviceParams) => {
-    const fetchGetSingleDevice = useCallback(() => {
+export const useGetDeviceApi = ({ id }: GetDeviceParams) => {
+    const fetchGetDevice = useCallback(() => {
         return DevicesDataservices.GetOne({ id });
     }, [id]);
 
     const dispatch = useAppDispatch();
-    const dispatchRefreshDevices = useCallback(
+    const dispatchRefreshDevice = useCallback(
         (data: DeviceItem) => {
-            dispatch(devicesActions.refreshSingleDevice(data));
+            dispatch(devicesActions.refreshDevice(data));
         },
         [dispatch]
     );
 
     const { isLoading, error, fetchApi } = useFetchApi<DeviceItem>({
         initialData: null,
-        fetchMethod: fetchGetSingleDevice,
-        callbackFunc: dispatchRefreshDevices,
+        fetchMethod: fetchGetDevice,
+        callbackFunc: dispatchRefreshDevice,
     });
 
     return {
         isLoading,
         error,
-        getSingleDeviceApi: fetchApi,
+        getDeviceApi: fetchApi,
     };
 };
 
-export const useUpdateSingleDeviceApi = ({
-    id,
-    editedData,
-}: UpdateSingleDeviceParams) => {
-    const fetchUpdateSingleDevice = useCallback(
+export const useUpdateDeviceApi = ({ id, editedData }: UpdateDeviceParams) => {
+    const fetchUpdateDevice = useCallback(
         () =>
             DevicesDataservices.UpdateOne({
                 id,
@@ -83,20 +80,18 @@ export const useUpdateSingleDeviceApi = ({
 
     const dispatch = useAppDispatch();
     const dispatchRefreshDevices = useCallback(
-        (data: UpdateSingleDeviceResponseData) => {
+        (data: UpdateDeviceResponseData) => {
             if (data.status === RESPONSE_STATUS.OK) {
-                dispatch(
-                    devicesActions.updateSingleDevice({ ...editedData, id })
-                );
+                dispatch(devicesActions.updateDevice({ ...editedData, id }));
             }
         },
         [editedData, id, dispatch]
     );
 
     const { isLoading, error, fetchApi } =
-        useFetchApi<UpdateSingleDeviceResponseData>({
+        useFetchApi<UpdateDeviceResponseData>({
             initialData: null,
-            fetchMethod: fetchUpdateSingleDevice,
+            fetchMethod: fetchUpdateDevice,
             callbackFunc: dispatchRefreshDevices,
         });
 
@@ -108,14 +103,14 @@ export const useUpdateSingleDeviceApi = ({
 };
 
 export const useGetDevicePinsApi = ({ id }: GetDevicePinsParams) => {
-    const fetchGetSingleDevice = useCallback(
+    const fetchGetDevice = useCallback(
         () => DevicesDataservices.GetOnePins({ id }),
         [id]
     );
 
     const { isLoading, error, data, fetchApi } = useFetchApi<PinItem[]>({
         initialData: null,
-        fetchMethod: fetchGetSingleDevice,
+        fetchMethod: fetchGetDevice,
     });
 
     return {

--- a/dashboard/src/hooks/apis/oauth-clients.hook.ts
+++ b/dashboard/src/hooks/apis/oauth-clients.hook.ts
@@ -10,7 +10,7 @@ import {
 } from '@/constants/api';
 import { ApiHelpers } from '@/helpers/api.helper';
 import { OauthClient } from '@/types/oauth-clients.type';
-import { ResponseStatus } from '@/types/response.type';
+import { ResponseOK } from '@/types/response.type';
 
 interface PaginationOauthClientType {
     oauthClients: OauthClient[];
@@ -89,7 +89,7 @@ export const useUpdateOauthClient = ({
     const fetchMethod = useCallback(async () => {
         let apiPath = `${API_URL}${END_POINT.OAUTH_CLIENT}`;
         apiPath = apiPath.replace(':id', id.toString());
-        const result = await ApiHelpers.SendRequestWithToken<ResponseStatus>({
+        const result = await ApiHelpers.SendRequestWithToken<ResponseOK>({
             apiPath,
             method: HTTP_METHOD.PATCH,
             payload: {
@@ -101,7 +101,7 @@ export const useUpdateOauthClient = ({
 
     const dispatch = useAppDispatch();
     const dispatchRefresh = useCallback(
-        (data: ResponseStatus) => {
+        (data: ResponseOK) => {
             if (data.status === RESPONSE_STATUS.OK) {
                 dispatch(
                     oauthClientsActions.updateOne({
@@ -114,7 +114,7 @@ export const useUpdateOauthClient = ({
         [clientId, id, dispatch]
     );
 
-    return useFetchApi<ResponseStatus>({
+    return useFetchApi<ResponseOK>({
         initialData: null,
         fetchMethod,
         callbackFunc: dispatchRefresh,
@@ -159,7 +159,7 @@ export const useRevokeSecretOauthClient = (id: number) => {
 export const useDeleteOauthClients = (ids: number[]) => {
     const fetchMethod = useCallback(async () => {
         const apiPath = `${API_URL}${END_POINT.OAUTH_CLIENTS}`;
-        const result = await ApiHelpers.SendRequestWithToken<ResponseStatus>({
+        const result = await ApiHelpers.SendRequestWithToken<ResponseOK>({
             apiPath,
             method: HTTP_METHOD.DELETE,
             payload: ids,
@@ -169,7 +169,7 @@ export const useDeleteOauthClients = (ids: number[]) => {
 
     const dispatch = useAppDispatch();
     const dispatchRefresh = useCallback(
-        (data: ResponseStatus) => {
+        (data: ResponseOK) => {
             if (data.status === RESPONSE_STATUS.OK) {
                 dispatch(
                     oauthClientsActions.deleteMultiple({
@@ -181,7 +181,7 @@ export const useDeleteOauthClients = (ids: number[]) => {
         [ids, dispatch]
     );
 
-    return useFetchApi<ResponseStatus>({
+    return useFetchApi<ResponseOK>({
         initialData: null,
         fetchMethod,
         callbackFunc: dispatchRefresh,

--- a/dashboard/src/hooks/apis/oauth-clients.hook.ts
+++ b/dashboard/src/hooks/apis/oauth-clients.hook.ts
@@ -159,7 +159,7 @@ export const useRevokeSecretOauthClient = (id: number) => {
 export const useDeleteOauthClients = (ids: number[]) => {
     const fetchMethod = useCallback(async () => {
         const apiPath = `${API_URL}${END_POINT.OAUTH_CLIENTS}`;
-        const result = await ApiHelpers.SendRequestWithToken<any>({
+        const result = await ApiHelpers.SendRequestWithToken<ResponseOK>({
             apiPath,
             method: HTTP_METHOD.DELETE,
             payload: ids,
@@ -169,7 +169,7 @@ export const useDeleteOauthClients = (ids: number[]) => {
 
     const dispatch = useAppDispatch();
     const dispatchRefresh = useCallback(
-        (data: any) => {
+        (data: ResponseOK) => {
             if (data.status === RESPONSE_STATUS.OK) {
                 dispatch(
                     oauthClientsActions.deleteMultiple({
@@ -181,7 +181,7 @@ export const useDeleteOauthClients = (ids: number[]) => {
         [ids, dispatch]
     );
 
-    return useFetchApi<any>({
+    return useFetchApi<ResponseOK>({
         initialData: null,
         fetchMethod,
         callbackFunc: dispatchRefresh,

--- a/dashboard/src/hooks/apis/oauth-clients.hook.ts
+++ b/dashboard/src/hooks/apis/oauth-clients.hook.ts
@@ -10,7 +10,7 @@ import {
 } from '@/constants/api';
 import { ApiHelpers } from '@/helpers/api.helper';
 import { OauthClient } from '@/types/oauth-clients.type';
-import { ResponseOK } from '@/types/response.type';
+import { ResponseStatus } from '@/types/response.type';
 
 interface PaginationOauthClientType {
     oauthClients: OauthClient[];
@@ -89,7 +89,7 @@ export const useUpdateOauthClient = ({
     const fetchMethod = useCallback(async () => {
         let apiPath = `${API_URL}${END_POINT.OAUTH_CLIENT}`;
         apiPath = apiPath.replace(':id', id.toString());
-        const result = await ApiHelpers.SendRequestWithToken<ResponseOK>({
+        const result = await ApiHelpers.SendRequestWithToken<ResponseStatus>({
             apiPath,
             method: HTTP_METHOD.PATCH,
             payload: {
@@ -101,7 +101,7 @@ export const useUpdateOauthClient = ({
 
     const dispatch = useAppDispatch();
     const dispatchRefresh = useCallback(
-        (data: ResponseOK) => {
+        (data: ResponseStatus) => {
             if (data.status === RESPONSE_STATUS.OK) {
                 dispatch(
                     oauthClientsActions.updateOne({
@@ -114,7 +114,7 @@ export const useUpdateOauthClient = ({
         [clientId, id, dispatch]
     );
 
-    return useFetchApi<ResponseOK>({
+    return useFetchApi<ResponseStatus>({
         initialData: null,
         fetchMethod,
         callbackFunc: dispatchRefresh,
@@ -159,7 +159,7 @@ export const useRevokeSecretOauthClient = (id: number) => {
 export const useDeleteOauthClients = (ids: number[]) => {
     const fetchMethod = useCallback(async () => {
         const apiPath = `${API_URL}${END_POINT.OAUTH_CLIENTS}`;
-        const result = await ApiHelpers.SendRequestWithToken<ResponseOK>({
+        const result = await ApiHelpers.SendRequestWithToken<ResponseStatus>({
             apiPath,
             method: HTTP_METHOD.DELETE,
             payload: ids,
@@ -169,7 +169,7 @@ export const useDeleteOauthClients = (ids: number[]) => {
 
     const dispatch = useAppDispatch();
     const dispatchRefresh = useCallback(
-        (data: ResponseOK) => {
+        (data: ResponseStatus) => {
             if (data.status === RESPONSE_STATUS.OK) {
                 dispatch(
                     oauthClientsActions.deleteMultiple({
@@ -181,7 +181,7 @@ export const useDeleteOauthClients = (ids: number[]) => {
         [ids, dispatch]
     );
 
-    return useFetchApi<ResponseOK>({
+    return useFetchApi<ResponseStatus>({
         initialData: null,
         fetchMethod,
         callbackFunc: dispatchRefresh,

--- a/dashboard/src/hooks/apis/oauth-clients.hook.ts
+++ b/dashboard/src/hooks/apis/oauth-clients.hook.ts
@@ -14,7 +14,7 @@ import { ResponseOK } from '@/types/response.type';
 
 interface PaginationOauthClientType {
     oauthClients: OauthClient[];
-    rowNums: number;
+    rowNum: number;
 }
 
 export const useGetOauthClients = ({

--- a/dashboard/src/hooks/apis/triggers.hook.ts
+++ b/dashboard/src/hooks/apis/triggers.hook.ts
@@ -50,3 +50,59 @@ export const useGetTriggersApi = ({
         getTriggersApi: fetchApi,
     };
 };
+
+export const useGetTriggerApi = (id: number) => {
+    const fetchGetTriggerMethod = useCallback(async () => {
+        let apiPath = `${API_URL}${END_POINT.TRIGGER}`;
+        apiPath = apiPath.replace(':id', id.toString());
+
+        // const result = await ApiHelpers.SendRequestWithToken<TriggerItem>({
+        //     apiPath,
+        //     method: HTTP_METHOD.GET,
+        // });
+
+        /**
+         * 目前 API 尚未實作完成，先吐假資料，待接下來實作 API 後，
+         * 再把打開上面打 API 的程式、下面 return 拔掉，直接回傳 “result.data” 即可。
+         * */
+        return {
+            createdAt: '2022-01-09T22:44:58',
+            deletedAt: null,
+            destinationDevice: {},
+            destinationDeviceId: 60,
+            destinationDeviceSourceState: 0,
+            destinationDeviceTargetState: 1,
+            destinationPin: 'D3',
+            editedAt: null,
+            id: 2,
+            operator: 0,
+            ownerId: 23,
+            sourceDevice: {},
+            sourceDeviceId: 60,
+            sourcePin: 'D2',
+            sourceThreshold: 62,
+        } as TriggerItem;
+    }, [id]);
+
+    const dispatch = useAppDispatch();
+    const dispatchRefreshTrigger = useCallback(
+        (data: TriggerItem) => {
+            if (data) {
+                dispatch(triggersActions.refreshTrigger(data));
+            }
+        },
+        [dispatch]
+    );
+
+    const { isLoading, error, fetchApi } = useFetchApi<TriggerItem>({
+        initialData: null,
+        fetchMethod: fetchGetTriggerMethod,
+        callbackFunc: dispatchRefreshTrigger,
+    });
+
+    return {
+        isGettingTrigger: isLoading,
+        getTriggerError: error,
+        getTriggerApi: fetchApi,
+    };
+};

--- a/dashboard/src/hooks/apis/triggers.hook.ts
+++ b/dashboard/src/hooks/apis/triggers.hook.ts
@@ -1,0 +1,52 @@
+import { useCallback } from 'react';
+import { useAppDispatch } from '@/hooks/redux.hook';
+import { useFetchApi } from '@/hooks/apis/fetch.hook';
+import { triggersActions } from '@/redux/reducers/triggers.reducer';
+import { API_URL, END_POINT, HTTP_METHOD } from '@/constants/api';
+import { ApiHelpers } from '@/helpers/api.helper';
+import { TriggerItem } from '@/types/triggers.type';
+
+interface GetTriggersResponse {
+    triggers: TriggerItem[];
+    rowNums: number;
+}
+
+export const useGetTriggersApi = ({
+    page,
+    limit,
+}: {
+    page: number;
+    limit: number;
+}) => {
+    const fetchGetTriggersMethod = useCallback(async () => {
+        const apiPath = `${API_URL}${END_POINT.TRIGGERS}?page=${page}&limit=${limit}`;
+        const result =
+            await ApiHelpers.SendRequestWithToken<GetTriggersResponse>({
+                apiPath,
+                method: HTTP_METHOD.GET,
+            });
+        return result.data;
+    }, [page, limit]);
+
+    const dispatch = useAppDispatch();
+    const dispatchRefreshTriggers = useCallback(
+        (data: GetTriggersResponse) => {
+            if (data) {
+                dispatch(triggersActions.refreshTriggers(data));
+            }
+        },
+        [dispatch]
+    );
+
+    const { isLoading, error, fetchApi } = useFetchApi<GetTriggersResponse>({
+        initialData: null,
+        fetchMethod: fetchGetTriggersMethod,
+        callbackFunc: dispatchRefreshTriggers,
+    });
+
+    return {
+        isGettingTriggers: isLoading,
+        getTriggersError: error,
+        getTriggersApi: fetchApi,
+    };
+};

--- a/dashboard/src/hooks/apis/triggers.hook.ts
+++ b/dashboard/src/hooks/apis/triggers.hook.ts
@@ -142,8 +142,8 @@ export const useDeleteTriggersApi = (ids: number[]) => {
 
     return {
         isDeletingTriggers: isLoading,
-        deletingTriggersError: error,
-        deletingTriggersResponse: data,
-        deletingTriggersApi: fetchApi,
+        deleteTriggersError: error,
+        deleteTriggersResponse: data,
+        deleteTriggersApi: fetchApi,
     };
 };

--- a/dashboard/src/hooks/apis/triggers.hook.ts
+++ b/dashboard/src/hooks/apis/triggers.hook.ts
@@ -10,7 +10,7 @@ import {
 } from '@/constants/api';
 import { ApiHelpers } from '@/helpers/api.helper';
 import { TriggerItem } from '@/types/triggers.type';
-import { ResponseOK } from '@/types/response.type';
+import { ResponseStatus } from '@/types/response.type';
 
 interface GetTriggersResponse {
     triggers: TriggerItem[];
@@ -116,7 +116,7 @@ export const useGetTriggerApi = (id: number) => {
 export const useDeleteTriggersApi = (ids: number[]) => {
     const fetchDeleteTriggers = useCallback(async () => {
         const apiPath = `${API_URL}${END_POINT.TRIGGERS}`;
-        const result = await ApiHelpers.SendRequestWithToken<ResponseOK>({
+        const result = await ApiHelpers.SendRequestWithToken<ResponseStatus>({
             apiPath,
             method: HTTP_METHOD.DELETE,
             payload: ids,
@@ -126,7 +126,7 @@ export const useDeleteTriggersApi = (ids: number[]) => {
 
     const dispatch = useAppDispatch();
     const dispatchRefresh = useCallback(
-        (data: ResponseOK) => {
+        (data: ResponseStatus) => {
             if (data.status === RESPONSE_STATUS.OK) {
                 dispatch(triggersActions.deleteTriggers(ids));
             }
@@ -134,7 +134,7 @@ export const useDeleteTriggersApi = (ids: number[]) => {
         [ids, dispatch]
     );
 
-    const { isLoading, error, data, fetchApi } = useFetchApi<ResponseOK>({
+    const { isLoading, error, data, fetchApi } = useFetchApi<ResponseStatus>({
         initialData: null,
         fetchMethod: fetchDeleteTriggers,
         callbackFunc: dispatchRefresh,

--- a/dashboard/src/hooks/apis/triggers.hook.ts
+++ b/dashboard/src/hooks/apis/triggers.hook.ts
@@ -10,7 +10,7 @@ import {
 } from '@/constants/api';
 import { ApiHelpers } from '@/helpers/api.helper';
 import { TriggerItem } from '@/types/triggers.type';
-import { ResponseStatus } from '@/types/response.type';
+import { ResponseOK } from '@/types/response.type';
 
 interface GetTriggersResponse {
     triggers: TriggerItem[];
@@ -96,7 +96,7 @@ export const useGetTriggerApi = (id: number) => {
 export const useDeleteTriggersApi = (ids: number[]) => {
     const fetchDeleteTriggers = useCallback(async () => {
         const apiPath = `${API_URL}${END_POINT.TRIGGERS}`;
-        const result = await ApiHelpers.SendRequestWithToken<ResponseStatus>({
+        const result = await ApiHelpers.SendRequestWithToken<ResponseOK>({
             apiPath,
             method: HTTP_METHOD.DELETE,
             payload: ids,
@@ -106,7 +106,7 @@ export const useDeleteTriggersApi = (ids: number[]) => {
 
     const dispatch = useAppDispatch();
     const dispatchRefresh = useCallback(
-        (data: ResponseStatus) => {
+        (data: ResponseOK) => {
             if (data.status === RESPONSE_STATUS.OK) {
                 dispatch(triggersActions.deleteTriggers(ids));
             }
@@ -114,7 +114,7 @@ export const useDeleteTriggersApi = (ids: number[]) => {
         [ids, dispatch]
     );
 
-    const { isLoading, error, data, fetchApi } = useFetchApi<ResponseStatus>({
+    const { isLoading, error, data, fetchApi } = useFetchApi<ResponseOK>({
         initialData: null,
         fetchMethod: fetchDeleteTriggers,
         callbackFunc: dispatchRefresh,

--- a/dashboard/src/hooks/apis/triggers.hook.ts
+++ b/dashboard/src/hooks/apis/triggers.hook.ts
@@ -62,32 +62,12 @@ export const useGetTriggerApi = (id: number) => {
         let apiPath = `${API_URL}${END_POINT.TRIGGER}`;
         apiPath = apiPath.replace(':id', id.toString());
 
-        // const result = await ApiHelpers.SendRequestWithToken<TriggerItem>({
-        //     apiPath,
-        //     method: HTTP_METHOD.GET,
-        // });
+        const result = await ApiHelpers.SendRequestWithToken<TriggerItem>({
+            apiPath,
+            method: HTTP_METHOD.GET,
+        });
 
-        /**
-         * 目前 API 尚未實作完成，先吐假資料，待接下來實作 API 後，
-         * 再把打開上面打 API 的程式、下面 return 拔掉，直接回傳 “result.data” 即可。
-         * */
-        return {
-            createdAt: '2022-01-09T22:44:58',
-            deletedAt: null,
-            destinationDevice: {},
-            destinationDeviceId: 60,
-            destinationDeviceSourceState: 0,
-            destinationDeviceTargetState: 1,
-            destinationPin: 'D3',
-            editedAt: null,
-            id: 2,
-            operator: 0,
-            ownerId: 23,
-            sourceDevice: {},
-            sourceDeviceId: 60,
-            sourcePin: 'D2',
-            sourceThreshold: 62,
-        } as TriggerItem;
+        return result.data;
     }, [id]);
 
     const dispatch = useAppDispatch();

--- a/dashboard/src/hooks/apis/triggers.hook.ts
+++ b/dashboard/src/hooks/apis/triggers.hook.ts
@@ -14,7 +14,7 @@ import { ResponseOK } from '@/types/response.type';
 
 interface GetTriggersResponse {
     triggers: TriggerItem[];
-    rowNums: number;
+    rowNum: number;
 }
 
 export const useGetTriggersApi = ({

--- a/dashboard/src/pages/device/device.tsx
+++ b/dashboard/src/pages/device/device.tsx
@@ -1,10 +1,7 @@
 import styles from './device.module.scss';
 import { useState, useEffect } from 'react';
 import { Link, useParams } from 'react-router-dom';
-import {
-    useGetSingleDeviceApi,
-    useUpdateSingleDeviceApi,
-} from '@/hooks/apis/devices.hook';
+import { useGetDeviceApi, useUpdateDeviceApi } from '@/hooks/apis/devices.hook';
 import { DeviceItem } from '@/types/devices.type';
 import { useAppSelector } from '@/hooks/redux.hook';
 import { selectDevices } from '@/redux/reducers/devices.reducer';
@@ -28,17 +25,17 @@ const Device = () => {
     const [editedData, setEditedData] =
         useState<Partial<DeviceItem>>(initialEditedData);
 
-    const { isLoading, getSingleDeviceApi } = useGetSingleDeviceApi({
+    const { isLoading, getDeviceApi } = useGetDeviceApi({
         id: numId,
     });
-    const { updateSingleDeviceApi } = useUpdateSingleDeviceApi({
+    const { updateSingleDeviceApi } = useUpdateDeviceApi({
         id: numId,
         editedData: editedData,
     });
 
     useEffect(() => {
         if (device === null) {
-            getSingleDeviceApi();
+            getDeviceApi();
         }
     }, []);
 

--- a/dashboard/src/pages/device/device.tsx
+++ b/dashboard/src/pages/device/device.tsx
@@ -28,7 +28,7 @@ const Device = () => {
     const { isLoading, getDeviceApi } = useGetDeviceApi({
         id: numId,
     });
-    const { updateSingleDeviceApi } = useUpdateDeviceApi({
+    const { updateDeviceApi } = useUpdateDeviceApi({
         id: numId,
         editedData: editedData,
     });
@@ -44,7 +44,7 @@ const Device = () => {
     };
 
     const updateDeviceData = () => {
-        updateSingleDeviceApi();
+        updateDeviceApi();
         setEditedData(initialEditedData);
         closeModal();
     };

--- a/dashboard/src/pages/oauth-clients/oauth-clients.tsx
+++ b/dashboard/src/pages/oauth-clients/oauth-clients.tsx
@@ -16,7 +16,7 @@ const OauthClients = () => {
     const limit = Number(query.get('limit') || 5);
     const [page, setPage] = useState(Number(query.get('page') || 1));
     const list = useAppSelector(selectOauthClients);
-    const [rowNums, setRowNums] = useState(0);
+    const [rowNum, setRowNum] = useState(0);
     const { isLoading, fetchApi, data } = useGetOauthClients({ page, limit });
     const [selectedIds, setSelectedIds] = useState(Array<number>());
     const [refreshFlag, setRefreshFlag] = useState(false);
@@ -36,10 +36,10 @@ const OauthClients = () => {
     }, [page, refreshFlag]);
 
     useEffect(() => {
-        if (data && data.rowNums) {
-            setRowNums(data?.rowNums);
+        if (data && data.rowNum) {
+            setRowNum(data?.rowNum);
         } else {
-            setRowNums(0);
+            setRowNum(0);
         }
     }, [data]);
 
@@ -102,7 +102,7 @@ const OauthClients = () => {
                 ))
             )}
             <div>Page: {page}</div>
-            <Pagination rowNums={rowNums} page={page} limit={limit} />
+            <Pagination rowNum={rowNum} page={page} limit={limit} />
         </div>
     );
 };

--- a/dashboard/src/pages/trigger/trigger.module.scss
+++ b/dashboard/src/pages/trigger/trigger.module.scss
@@ -1,2 +1,2 @@
-.Trigger {
+.trigger {
 }

--- a/dashboard/src/pages/trigger/trigger.tsx
+++ b/dashboard/src/pages/trigger/trigger.tsx
@@ -1,13 +1,42 @@
 import styles from './trigger.module.scss';
+import { useEffect } from 'react';
 import { Link, useParams } from 'react-router-dom';
+import { useAppSelector } from '@/hooks/redux.hook';
+import { useGetTriggerApi } from '@/hooks/apis/triggers.hook';
+import { selectTriggers } from '@/redux/reducers/triggers.reducer';
 
 const Trigger = () => {
     const { id } = useParams();
+    const numId = Number(id);
+    const { triggers } = useAppSelector(selectTriggers);
+    const trigger =
+        triggers?.filter((trigger) => trigger.id === numId)[0] || null;
+
+    const { isGettingTrigger, getTriggerApi } = useGetTriggerApi(numId);
+    useEffect(() => {
+        if (trigger === null) {
+            getTriggerApi();
+        }
+    }, []);
+
     return (
-        <div className={styles.Trigger} data-testid="Trigger">
-            Trigger Component <br />
-            id: {id} <br />
-            <Link to="../triggers">Back</Link>
+        <div className={styles.trigger} data-testid="trigger">
+            {isGettingTrigger || trigger === null ? (
+                <div>Loading</div>
+            ) : (
+                <>
+                    <div>Id: {trigger.id}</div>
+                    <div>OwnerId: {trigger.ownerId}</div>
+                    <div>Source Device Name: {trigger.sourceDevice.name}</div>
+                    <div>Source Device Pin: {trigger.sourcePin}</div>
+                    <div>
+                        Destination Device Name:{' '}
+                        {trigger.destinationDevice.name}
+                    </div>
+                    <div>Destination Device Pin: {trigger.destinationPin}</div>
+                    <Link to="../triggers">Back to triggers</Link>
+                </>
+            )}
         </div>
     );
 };

--- a/dashboard/src/pages/trigger/trigger.tsx
+++ b/dashboard/src/pages/trigger/trigger.tsx
@@ -27,11 +27,14 @@ const Trigger = () => {
                 <>
                     <div>Id: {trigger.id}</div>
                     <div>OwnerId: {trigger.ownerId}</div>
-                    <div>Source Device Name: {trigger.sourceDevice.name}</div>
+                    <div>
+                        Source Device Name:{' '}
+                        {trigger.sourceDevice?.name || 'No Data'}
+                    </div>
                     <div>Source Device Pin: {trigger.sourcePin}</div>
                     <div>
                         Destination Device Name:{' '}
-                        {trigger.destinationDevice.name}
+                        {trigger.destinationDevice?.name || 'No Data'}
                     </div>
                     <div>Destination Device Pin: {trigger.destinationPin}</div>
                     <Link to="../triggers">Back to triggers</Link>

--- a/dashboard/src/pages/triggers/triggers.module.scss
+++ b/dashboard/src/pages/triggers/triggers.module.scss
@@ -1,2 +1,4 @@
-.Triggers {
+.triggers {
+    display: flex;
+    flex-direction: column;
 }

--- a/dashboard/src/pages/triggers/triggers.tsx
+++ b/dashboard/src/pages/triggers/triggers.tsx
@@ -1,12 +1,52 @@
 import styles from './triggers.module.scss';
+import { useEffect } from 'react';
 import { Link } from 'react-router-dom';
+import { useQuery } from '@/hooks/query.hook';
+import { useAppSelector } from '@/hooks/redux.hook';
+import { useGetTriggersApi } from '@/hooks/apis/triggers.hook';
+import { selectTriggers } from '@/redux/reducers/triggers.reducer';
+import Pagination from '@/components/pagination/pagination';
 
-const Triggers = () => (
-    <div className={styles.Triggers} data-testid="Triggers">
-        Triggers Component
-        <br />
-        <Link to="/dashboard/triggers/1">No 1 Trigger</Link>
-    </div>
-);
+const Triggers = () => {
+    const query = useQuery();
+    const limit = Number(query.get('limit') || 5);
+    const page = Number(query.get('page') || 1);
+
+    const { triggers, rowNums } = useAppSelector(selectTriggers);
+
+    const { isGettingTriggers, getTriggersApi } = useGetTriggersApi({
+        page,
+        limit,
+    });
+
+    useEffect(() => {
+        getTriggersApi();
+    }, [page]);
+
+    return (
+        <div className={styles.Triggers} data-testid="Triggers">
+            {isGettingTriggers || triggers === null ? (
+                <div>Loading</div>
+            ) : (
+                triggers.map(({ id, ownerId }) => (
+                    <label className="d-flex align-items-top" key={id}>
+                        <div>
+                            <div>
+                                <span>Id</span>
+                                <span>OwnerId</span>
+                            </div>
+                            <Link to={`/dashboard/trigger/${id}`}>
+                                <span>{id}</span>
+                                <span>{ownerId}</span>
+                            </Link>
+                        </div>
+                    </label>
+                ))
+            )}
+            <div>Page: {page}</div>
+            <Pagination page={page} rowNums={rowNums} limit={limit} />
+        </div>
+    );
+};
 
 export default Triggers;

--- a/dashboard/src/pages/triggers/triggers.tsx
+++ b/dashboard/src/pages/triggers/triggers.tsx
@@ -91,12 +91,13 @@ const Triggers = () => {
                                 <div>Id: {id}</div>
                                 <div>OwnerId: {ownerId}</div>
                                 <div>
-                                    Source Device Name: {sourceDevice.name}
+                                    Source Device Name:{' '}
+                                    {sourceDevice?.name || 'No Data'}
                                 </div>
                                 <div>Source Device Pin: {sourcePin}</div>
                                 <div>
                                     Destination Device Name:{' '}
-                                    {destinationDevice.name}
+                                    {destinationDevice?.name || 'No Data'}
                                 </div>
                                 <div>
                                     Destination Device Pin: {destinationPin}

--- a/dashboard/src/pages/triggers/triggers.tsx
+++ b/dashboard/src/pages/triggers/triggers.tsx
@@ -16,7 +16,7 @@ const Triggers = () => {
     const limit = Number(query.get('limit') || 5);
     const page = Number(query.get('page') || 1);
 
-    const { triggers, rowNums } = useAppSelector(selectTriggers);
+    const { triggers, rowNum } = useAppSelector(selectTriggers);
 
     const [selectedIds, setSelectedIds] = useState(Array<number>());
 
@@ -110,7 +110,7 @@ const Triggers = () => {
                     )
                 )}
                 <div>Page: {page}</div>
-                <Pagination page={page} rowNums={rowNums} limit={limit} />
+                <Pagination page={page} rowNum={rowNum} limit={limit} />
             </div>
         </>
     );

--- a/dashboard/src/pages/triggers/triggers.tsx
+++ b/dashboard/src/pages/triggers/triggers.tsx
@@ -24,24 +24,35 @@ const Triggers = () => {
     }, [page]);
 
     return (
-        <div className={styles.Triggers} data-testid="Triggers">
+        <div className={styles.triggers} data-testid="triggers">
             {isGettingTriggers || triggers === null ? (
                 <div>Loading</div>
             ) : (
-                triggers.map(({ id, ownerId }) => (
-                    <label className="d-flex align-items-top" key={id}>
-                        <div>
+                triggers.map(
+                    ({
+                        id,
+                        ownerId,
+                        sourceDevice,
+                        sourcePin,
+                        destinationDevice,
+                        destinationPin,
+                    }) => (
+                        <label key={id} className="mt-3 mb-3">
+                            <div>Id: {id}</div>
+                            <div>OwnerId: {ownerId}</div>
+                            <div>Source Device Name: {sourceDevice.name}</div>
+                            <div>Source Device Pin: {sourcePin}</div>
                             <div>
-                                <span>Id</span>
-                                <span>OwnerId</span>
+                                Destination Device Name:{' '}
+                                {destinationDevice.name}
                             </div>
-                            <Link to={`/dashboard/trigger/${id}`}>
-                                <span>{id}</span>
-                                <span>{ownerId}</span>
+                            <div>Destination Device Pin: {destinationPin}</div>
+                            <Link to={`../triggers/${id}`}>
+                                Go to id:{id} trigger
                             </Link>
-                        </div>
-                    </label>
-                ))
+                        </label>
+                    )
+                )
             )}
             <div>Page: {page}</div>
             <Pagination page={page} rowNums={rowNums} limit={limit} />

--- a/dashboard/src/pages/triggers/triggers.tsx
+++ b/dashboard/src/pages/triggers/triggers.tsx
@@ -1,6 +1,7 @@
 import styles from './triggers.module.scss';
 import { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
+import { RESPONSE_STATUS } from '@/constants/api';
 import { useQuery } from '@/hooks/query.hook';
 import { useAppSelector } from '@/hooks/redux.hook';
 import {
@@ -24,12 +25,21 @@ const Triggers = () => {
         limit,
     });
 
-    const { isDeletingTriggers, deletingTriggersApi } =
+    const { isDeletingTriggers, deleteTriggersApi, deleteTriggersResponse } =
         useDeleteTriggersApi(selectedIds);
 
     useEffect(() => {
         getTriggersApi();
     }, [page]);
+
+    useEffect(() => {
+        if (
+            deleteTriggersResponse &&
+            deleteTriggersResponse.status === RESPONSE_STATUS.OK
+        ) {
+            getTriggersApi();
+        }
+    }, [deleteTriggersResponse]);
 
     const checkSelectedIds = (event: React.ChangeEvent<HTMLInputElement>) => {
         setSelectedIds((previous) => {
@@ -52,7 +62,7 @@ const Triggers = () => {
     return (
         <>
             <button
-                onClick={deletingTriggersApi}
+                onClick={deleteTriggersApi}
                 disabled={isDeletingTriggers || selectedIds.length <= 0}
             >
                 {isDeletingTriggers

--- a/dashboard/src/redux/reducers/devices.reducer.ts
+++ b/dashboard/src/redux/reducers/devices.reducer.ts
@@ -10,7 +10,7 @@ export const devicesSlice = createSlice({
             const newDevices = action.payload;
             return newDevices;
         },
-        refreshSingleDevice: (state, action: PayloadAction<DeviceItem>) => {
+        refreshDevice: (state, action: PayloadAction<DeviceItem>) => {
             const devices = state;
             const newDeviceData = action.payload;
 
@@ -26,17 +26,12 @@ export const devicesSlice = createSlice({
             };
             return devices;
         },
-        updateSingleDevice: (
-            state,
-            action: PayloadAction<Partial<DeviceItem>>
-        ) => {
+        updateDevice: (state, action: PayloadAction<Partial<DeviceItem>>) => {
             const devices = state;
             const newDeviceData = action.payload;
 
             if (devices === null) {
-                throw new Error(
-                    'Can not updateSingleDevice when devices is null.'
-                );
+                throw new Error('Can not updateDevice when devices is null.');
             }
 
             const targetIndex = devices.findIndex(

--- a/dashboard/src/redux/reducers/oauth-clients.reducer.ts
+++ b/dashboard/src/redux/reducers/oauth-clients.reducer.ts
@@ -65,7 +65,7 @@ export const oauthClientsSlice = createSlice({
             }
 
             return list.filter(
-                (item) => deletePayload.ids.indexOf(item.id) !== -1
+                (item) => deletePayload.ids.indexOf(item.id) === -1
             );
         },
     },

--- a/dashboard/src/redux/reducers/oauth-clients.reducer.ts
+++ b/dashboard/src/redux/reducers/oauth-clients.reducer.ts
@@ -1,4 +1,4 @@
-import { createSelector, createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { RootState } from '@/redux/store';
 import { OauthClient } from '@/types/oauth-clients.type';
 

--- a/dashboard/src/redux/reducers/triggers.reducer.ts
+++ b/dashboard/src/redux/reducers/triggers.reducer.ts
@@ -77,7 +77,7 @@ export const triggersSlice = createSlice({
             }
 
             const updatedTriggers = triggers.filter(
-                (trigger) => deleteTriggerIds.indexOf(trigger.id) !== -1
+                (trigger) => deleteTriggerIds.indexOf(trigger.id) === -1
             );
 
             return {

--- a/dashboard/src/redux/reducers/triggers.reducer.ts
+++ b/dashboard/src/redux/reducers/triggers.reducer.ts
@@ -68,6 +68,23 @@ export const triggersSlice = createSlice({
                 triggers,
             };
         },
+        deleteTriggers: (state, action: PayloadAction<number[]>) => {
+            const triggers = state.triggers;
+            const deleteTriggerIds = action.payload;
+
+            if (triggers === null) {
+                throw new Error('Can not delete when triggers is null.');
+            }
+
+            const updatedTriggers = triggers.filter(
+                (trigger) => deleteTriggerIds.indexOf(trigger.id) !== -1
+            );
+
+            return {
+                ...state,
+                triggers: updatedTriggers,
+            };
+        },
     },
 });
 

--- a/dashboard/src/redux/reducers/triggers.reducer.ts
+++ b/dashboard/src/redux/reducers/triggers.reducer.ts
@@ -4,12 +4,12 @@ import { TriggerItem } from '@/types/triggers.type';
 
 type TriggersState = {
     triggers: TriggerItem[] | null;
-    rowNums: number;
+    rowNum: number;
 };
 
 const initialState: TriggersState = {
     triggers: null,
-    rowNums: 0,
+    rowNum: 0,
 };
 
 export const triggersSlice = createSlice({
@@ -18,11 +18,11 @@ export const triggersSlice = createSlice({
     reducers: {
         refreshTriggers: (state, action: PayloadAction<TriggersState>) => {
             const newTriggers = action.payload.triggers;
-            const newRowNums = action.payload.rowNums;
+            const newRowNums = action.payload.rowNum;
 
             return {
                 triggers: newTriggers,
-                rowNums: newRowNums,
+                rowNum: newRowNums,
             };
         },
         refreshTrigger: (state, action: PayloadAction<TriggerItem>) => {

--- a/dashboard/src/redux/reducers/triggers.reducer.ts
+++ b/dashboard/src/redux/reducers/triggers.reducer.ts
@@ -1,0 +1,78 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { RootState } from '@/redux/store';
+import { TriggerItem } from '@/types/triggers.type';
+
+type TriggersState = {
+    triggers: TriggerItem[] | null;
+    rowNums: number;
+};
+
+const initialState: TriggersState = {
+    triggers: null,
+    rowNums: 0,
+};
+
+export const triggersSlice = createSlice({
+    name: 'triggers',
+    initialState,
+    reducers: {
+        refreshTriggers: (state, action: PayloadAction<TriggersState>) => {
+            const newTriggers = action.payload.triggers;
+            const newRowNums = action.payload.rowNums;
+
+            return {
+                triggers: newTriggers,
+                rowNums: newRowNums,
+            };
+        },
+        refreshTrigger: (state, action: PayloadAction<TriggerItem>) => {
+            const triggers = state.triggers;
+            const newTrigger = action.payload;
+
+            if (triggers === null) {
+                return {
+                    ...state,
+                    triggers: [newTrigger],
+                };
+            }
+
+            const targetIndex = triggers.findIndex(
+                (trigger) => trigger.id === newTrigger.id
+            );
+            triggers[targetIndex] = {
+                ...newTrigger,
+            };
+            return {
+                ...state,
+                triggers,
+            };
+        },
+        updateTrigger: (state, action: PayloadAction<Partial<TriggerItem>>) => {
+            const triggers = state.triggers;
+            const newTrigger = action.payload;
+
+            if (triggers === null) {
+                throw new Error('Can not updateTrigger when triggers is null.');
+            }
+
+            const targetIndex = triggers.findIndex(
+                (trigger) => trigger.id === newTrigger.id
+            );
+            triggers[targetIndex] = {
+                ...triggers[targetIndex],
+                ...newTrigger,
+            };
+
+            return {
+                ...state,
+                triggers,
+            };
+        },
+    },
+});
+
+export const triggersActions = triggersSlice.actions;
+
+export const selectTriggers = (state: RootState) => state.triggers;
+
+export default triggersSlice.reducer;

--- a/dashboard/src/redux/store.ts
+++ b/dashboard/src/redux/store.ts
@@ -1,11 +1,13 @@
 import { configureStore } from '@reduxjs/toolkit';
 import devicesReducer from './reducers/devices.reducer';
 import oauthClientsReducer from './reducers/oauth-clients.reducer';
+import triggersReducer from './reducers/triggers.reducer';
 
 const store = configureStore({
     reducer: {
         devices: devicesReducer,
         oauthClients: oauthClientsReducer,
+        triggers: triggersReducer,
     },
 });
 

--- a/dashboard/src/types/dataservices.type.ts
+++ b/dashboard/src/types/dataservices.type.ts
@@ -7,7 +7,7 @@ export interface GetDevicesParams {
 
 export interface GetDevicesResponseData {
     devices: DeviceItem[];
-    rowNums: number;
+    rowNum: number;
 }
 
 export interface GetDeviceParams {

--- a/dashboard/src/types/dataservices.type.ts
+++ b/dashboard/src/types/dataservices.type.ts
@@ -1,4 +1,4 @@
-import { DeviceItem, PinItem } from './devices.type';
+import { DeviceItem } from './devices.type';
 
 export interface GetDevicesParams {
     page: number;
@@ -10,16 +10,16 @@ export interface GetDevicesResponseData {
     rowNums: number;
 }
 
-export interface GetSingleDeviceParams {
+export interface GetDeviceParams {
     id: number;
 }
 
-export interface UpdateSingleDeviceParams {
+export interface UpdateDeviceParams {
     id: number;
     editedData: Partial<DeviceItem>;
 }
 
-export interface UpdateSingleDeviceResponseData {
+export interface UpdateDeviceResponseData {
     status: string;
 }
 

--- a/dashboard/src/types/response.type.ts
+++ b/dashboard/src/types/response.type.ts
@@ -1,3 +1,3 @@
-export interface ResponseOK {
+export interface ResponseStatus {
     status: string;
 }

--- a/dashboard/src/types/response.type.ts
+++ b/dashboard/src/types/response.type.ts
@@ -1,3 +1,3 @@
-export interface ResponseStatus {
+export interface ResponseOK {
     status: string;
 }

--- a/dashboard/src/types/triggers.type.ts
+++ b/dashboard/src/types/triggers.type.ts
@@ -4,14 +4,14 @@ export interface TriggerItem {
     id: number;
     ownerId: number;
     createdAt: string;
-    editedAt: null | string;
+    editedAt: string | null;
     deletedAt: string | null;
     operator: number;
-    sourceDevice: DeviceItem;
+    sourceDevice: DeviceItem | null;
     sourceDeviceId: number;
     sourcePin: string;
     sourceThreshold: number;
-    destinationDevice: DeviceItem;
+    destinationDevice: DeviceItem | null;
     destinationDeviceId: number;
     destinationDeviceSourceState: number;
     destinationDeviceTargetState: number;

--- a/dashboard/src/types/triggers.type.ts
+++ b/dashboard/src/types/triggers.type.ts
@@ -1,0 +1,19 @@
+import { DeviceItem } from '@/types/devices.type';
+
+export interface TriggerItem {
+    id: number;
+    ownerId: number;
+    createdAt: string;
+    editedAt: null | string;
+    deletedAt: string | null;
+    operator: number;
+    sourceDevice: DeviceItem;
+    sourceDeviceId: number;
+    sourcePin: string;
+    sourceThreshold: number;
+    destinationDevice: DeviceItem;
+    destinationDeviceId: number;
+    destinationDeviceSourceState: number;
+    destinationDeviceTargetState: number;
+    destinationPin: string;
+}


### PR DESCRIPTION
https://github.com/miterfrants/itemhub/issues/248 中的部分 Tasks

# 修改內容

- 串接 GET triggers api、DELETE triggers api，實作 triggers 的 reducer、hook。
- 渲染 triggers 頁面，並有 pagination (取共用元件)。
- 渲染 trigger 頁面。

# 修改專案

- Dashboard F2E
- API (只有修改 key 命名，對齊 olient-clients)

# 測試網址和方式

- 進入 triggers / trigger page 會顯示 id / ownerId / source device name / source device pin / destination device name / destination device pin 相關資訊。

# Reviewers

@miterfrants @vickychou99 

# Todos

- DELETE 前可以跳個 Modal，做些確認動作，確保沒刪錯
- GET single trigger API
- CUD 的操作
