### PR TITLE
Refactor: refactor outh-clients rowNum and page state source

### DIFF
--- a/dashboard/src/hooks/apis/oauth-clients.hook.ts
+++ b/dashboard/src/hooks/apis/oauth-clients.hook.ts
@@ -38,7 +38,7 @@ export const useGetOauthClients = ({
     const dispatchRefresh = useCallback(
         (data: PaginationOauthClientType) => {
             if (data) {
-                dispatch(oauthClientsActions.refresh(data.oauthClients));
+                dispatch(oauthClientsActions.refresh(data));
             }
         },
         [dispatch]

--- a/dashboard/src/pages/oauth-client/oauth-client.tsx
+++ b/dashboard/src/pages/oauth-client/oauth-client.tsx
@@ -26,20 +26,21 @@ const OauthClient = () => {
 
     const navigate = useNavigate();
 
-    const list = useAppSelector(selectOauthClients);
+    const { oauthClients } = useAppSelector(selectOauthClients);
 
-    const oauthClient = (list || []).filter(
+    const oauthClient = (oauthClients || []).filter(
         (item) => item.id === Number(id)
     )[0];
-
     const oauthClientId = oauthClient ? oauthClient.clientId : '';
 
     const [clientId, setClientId] = useState(oauthClientId);
 
     const { isLoading, fetchApi } = useGetOauthClient(Number(id));
+
     const { fetchApi: updateApi, isLoading: isUpdating } = useUpdateOauthClient(
         { id: Number(id), clientId }
     );
+
     const {
         fetchApi: revokeSecretApi,
         isLoading: isRevoking,

--- a/dashboard/src/pages/oauth-client/oauth-client.tsx
+++ b/dashboard/src/pages/oauth-client/oauth-client.tsx
@@ -35,7 +35,9 @@ const OauthClient = () => {
 
     const [clientId, setClientId] = useState(oauthClientId);
 
-    const { isLoading, fetchApi } = useGetOauthClient(Number(id));
+    const { isLoading: isGetting, fetchApi: getApi } = useGetOauthClient(
+        Number(id)
+    );
 
     const { fetchApi: updateApi, isLoading: isUpdating } = useUpdateOauthClient(
         { id: Number(id), clientId }
@@ -60,11 +62,11 @@ const OauthClient = () => {
     } = useCreateOauthClients(clientId);
 
     useEffect(() => {
-        if (oauthClient || isCreateMode) {
+        if (oauthClient || isDeleting || isCreateMode) {
             return;
         }
-        fetchApi();
-    }, [fetchApi, oauthClient, id]);
+        getApi();
+    }, [getApi, oauthClient, isDeleting, isCreateMode]);
 
     useEffect(() => {
         setClientId(oauthClientId);
@@ -89,7 +91,7 @@ const OauthClient = () => {
 
     return (
         <div className={styles.OauthClient} data-testid="oauth-client">
-            {isLoading ? (
+            {isGetting ? (
                 <div>Loading</div>
             ) : (
                 <div>

--- a/dashboard/src/pages/oauth-clients/oauth-clients.tsx
+++ b/dashboard/src/pages/oauth-clients/oauth-clients.tsx
@@ -16,13 +16,12 @@ const OauthClients = () => {
     const limit = Number(query.get('limit') || 5);
     const page = Number(query.get('page') || 1);
 
-    const list = useAppSelector(selectOauthClients);
+    const { oauthClients, rowNum } = useAppSelector(selectOauthClients);
 
-    const [rowNum, setRowNum] = useState(0);
     const [selectedIds, setSelectedIds] = useState(Array<number>());
     const [refreshFlag, setRefreshFlag] = useState(false);
 
-    const { isLoading, fetchApi, data } = useGetOauthClients({
+    const { isLoading, fetchApi } = useGetOauthClients({
         page,
         limit,
     });
@@ -36,14 +35,6 @@ const OauthClients = () => {
     useEffect(() => {
         fetchApi();
     }, [page, refreshFlag]);
-
-    useEffect(() => {
-        if (data && data.rowNum) {
-            setRowNum(data?.rowNum);
-        } else {
-            setRowNum(0);
-        }
-    }, [data]);
 
     useEffect(() => {
         if (responseOfDelete?.status === RESPONSE_STATUS.OK) {
@@ -84,10 +75,10 @@ const OauthClients = () => {
                 </Link>
             </div>
 
-            {isLoading || list === null ? (
+            {isLoading || oauthClients === null ? (
                 <div>Loading</div>
             ) : (
-                list.map(({ id, clientId }) => (
+                oauthClients.map(({ id, clientId }) => (
                     <label className="d-flex align-items-top" key={id}>
                         <input type="checkbox" onChange={check} value={id} />
                         <div>

--- a/dashboard/src/pages/oauth-clients/oauth-clients.tsx
+++ b/dashboard/src/pages/oauth-clients/oauth-clients.tsx
@@ -14,22 +14,24 @@ import { RESPONSE_STATUS } from '@/constants/api';
 const OauthClients = () => {
     const query = useQuery();
     const limit = Number(query.get('limit') || 5);
-    const [page, setPage] = useState(Number(query.get('page') || 1));
+    const page = Number(query.get('page') || 1);
+
     const list = useAppSelector(selectOauthClients);
+
     const [rowNum, setRowNum] = useState(0);
-    const { isLoading, fetchApi, data } = useGetOauthClients({ page, limit });
     const [selectedIds, setSelectedIds] = useState(Array<number>());
     const [refreshFlag, setRefreshFlag] = useState(false);
+
+    const { isLoading, fetchApi, data } = useGetOauthClients({
+        page,
+        limit,
+    });
 
     const {
         isLoading: isDeleting,
         fetchApi: deleteMultipleApi,
         data: responseOfDelete,
     } = useDeleteOauthClients(selectedIds);
-
-    useEffect(() => {
-        setPage(Number(query.get('page') || 1));
-    }, [query]);
 
     useEffect(() => {
         fetchApi();

--- a/dashboard/src/redux/reducers/oauth-clients.reducer.ts
+++ b/dashboard/src/redux/reducers/oauth-clients.reducer.ts
@@ -72,11 +72,9 @@ export const oauthClientsSlice = createSlice({
                 list = [];
             }
 
-            list.push(newOne);
-
             return {
                 ...state,
-                oauthClients: list,
+                oauthClients: [newOne, ...list],
             };
         },
         deleteMultiple: (state, action: PayloadAction<{ ids: number[] }>) => {

--- a/dashboard/src/redux/reducers/oauth-clients.reducer.ts
+++ b/dashboard/src/redux/reducers/oauth-clients.reducer.ts
@@ -2,20 +2,33 @@ import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { RootState } from '@/redux/store';
 import { OauthClient } from '@/types/oauth-clients.type';
 
+type OauthClientState = {
+    oauthClients: OauthClient[] | null;
+    rowNum: number;
+};
+
+const initialState: OauthClientState = {
+    oauthClients: null,
+    rowNum: 0,
+};
+
 export const oauthClientsSlice = createSlice({
     name: 'oauth-clients',
-    initialState: null as OauthClient[] | null,
+    initialState,
     reducers: {
-        refresh: (state, action: PayloadAction<OauthClient[]>) => {
-            const list = action.payload;
-            return list;
+        refresh: (state, action: PayloadAction<OauthClientState>) => {
+            const newState = action.payload;
+            return newState;
         },
         refreshOne: (state, action: PayloadAction<OauthClient>) => {
-            const list = state;
+            const list = state.oauthClients;
             const newOne = action.payload;
 
             if (list === null) {
-                return [newOne];
+                return {
+                    ...state,
+                    triggers: [newOne],
+                };
             }
 
             const targetIndex = list.findIndex(
@@ -24,10 +37,14 @@ export const oauthClientsSlice = createSlice({
             list[targetIndex] = {
                 ...newOne,
             };
-            return list;
+
+            return {
+                ...state,
+                oauthClients: list,
+            };
         },
         updateOne: (state, action: PayloadAction<Partial<OauthClient>>) => {
-            const list = state;
+            const list = state.oauthClients;
             const newOne = action.payload;
 
             if (list === null) {
@@ -42,10 +59,13 @@ export const oauthClientsSlice = createSlice({
                 ...newOne,
             };
 
-            return list;
+            return {
+                ...state,
+                oauthClients: list,
+            };
         },
         addOne: (state, action: PayloadAction<OauthClient>) => {
-            let list = state;
+            let list = state.oauthClients;
             const newOne = action.payload;
 
             if (list === null) {
@@ -54,19 +74,27 @@ export const oauthClientsSlice = createSlice({
 
             list.push(newOne);
 
-            return list;
+            return {
+                ...state,
+                oauthClients: list,
+            };
         },
         deleteMultiple: (state, action: PayloadAction<{ ids: number[] }>) => {
-            const list = state;
+            const list = state.oauthClients;
             const deletePayload = action.payload;
 
             if (list === null) {
                 throw new Error('Can not delete when oauth-clients is null.');
             }
 
-            return list.filter(
+            const newList = list.filter(
                 (item) => deletePayload.ids.indexOf(item.id) === -1
             );
+
+            return {
+                ...state,
+                oauthClients: newList,
+            };
         },
     },
 });


### PR DESCRIPTION
# 修改內容

- 讓 outh-clients 的 page 來源只有從 query.page 來，而不會有內部 page state，統一資料來源
- 讓 outh-clients 的 rowNum 來源只有從 redux store 來，藉此統一 list api 資料來源皆由 store 來

p.s. 前面的兩個 pr merge 後，這個應該會有小衝突，我會再解掉

# 修改專案

- Dashboard F2E

# 測試網址和方式

- oauth-clients 頁面的 pagination 資料正常顯示與運作

# Reviewers

@miterfrants @vickychou99 
