### PR TITLE
feat: 把下線機制改成可以運作在多台 api server

### DIFF
--- a/api/Controllers/MyDeviceController.cs
+++ b/api/Controllers/MyDeviceController.cs
@@ -112,6 +112,7 @@ namespace Homo.IotApi
         {
             long ownerId = extraPayload.Id;
             DeviceDataservice.Switch(_dbContext, ownerId, id, true);
+            DeviceActivityLogDataservice.Create(_dbContext, ownerId, id);
             TimeoutOfflineDeviceService.StartAsync(ownerId, id, _dbConnectionString);
             return new { status = CUSTOM_RESPONSE.OK };
         }

--- a/api/Dataservices/DeviceActivityLogDataservice.cs
+++ b/api/Dataservices/DeviceActivityLogDataservice.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.EntityFrameworkCore;
+
+namespace Homo.IotApi
+{
+    public class DeviceActivityLogDataservice
+    {
+        public static int GetRowNumThis15Seconds(IotDbContext dbContext, long ownerId, long deviceId)
+        {
+            return dbContext.DeviceActivityLog.Where(x =>
+                x.DeletedAt == null
+                && x.DeviceId == deviceId
+                && x.OwnerId == ownerId
+                && (DateTime.Now - x.CreatedAt).TotalSeconds <= 15
+            ).Count();
+        }
+
+        public static DeviceActivityLog Create(IotDbContext dbContext, long ownerId, long deviceId)
+        {
+            DeviceActivityLog record = new DeviceActivityLog();
+            record.CreatedAt = DateTime.Now;
+            record.OwnerId = ownerId;
+            record.DeviceId = deviceId;
+            dbContext.DeviceActivityLog.Add(record);
+            dbContext.SaveChanges();
+            return record;
+        }
+    }
+}

--- a/api/Models/EF/DeviceActivityLog.cs
+++ b/api/Models/EF/DeviceActivityLog.cs
@@ -1,0 +1,17 @@
+using System;
+using Homo.Api;
+
+namespace Homo.IotApi
+{
+    public partial class DeviceActivityLog
+    {
+        public long Id { get; set; }
+        public DateTime CreatedAt { get; set; }
+        public DateTime? EditedAt { get; set; }
+        public DateTime? DeletedAt { get; set; }
+        [Required]
+        public long DeviceId { get; set; }
+        [Required]
+        public long OwnerId { get; set; }
+    }
+}

--- a/api/Models/EF/IotDbContext.cs
+++ b/api/Models/EF/IotDbContext.cs
@@ -30,6 +30,7 @@ namespace Homo.IotApi
         public virtual DbSet<Subscription> Subscription { get; set; }
         public virtual DbSet<Transaction> Transaction { get; set; }
         public virtual DbSet<ThirdPartyPaymentFlow> ThirdPartyPaymentFlow { get; set; }
+        public virtual DbSet<DeviceActivityLog> DeviceActivityLog { get; set; }
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
             base.OnModelCreating(modelBuilder);
@@ -105,6 +106,13 @@ namespace Homo.IotApi
             {
                 entity.HasIndex(p => new { p.CreatedAt });
                 entity.HasIndex(p => new { p.ExternalTransactionId });
+            });
+
+            modelBuilder.Entity<DeviceActivityLog>(entity =>
+            {
+                entity.HasIndex(p => new { p.CreatedAt });
+                entity.HasIndex(p => new { p.OwnerId });
+                entity.HasIndex(p => new { p.DeviceId });
             });
 
             OnModelCreatingPartial(modelBuilder);


### PR DESCRIPTION
# 修改內容

- Ref #292 
- 把裝置下線機制改成可以運作在多台 api server 狀況, 實作的原理: 把裝置活動的紀錄放在資料庫, 每一次裝置打一次 device online api 就會觸發計時器, 到這裡都跟舊的機制一樣, 不一樣在倒數計時器時間到了以後的 callback func 會去檢查裝置活動紀錄最後一次的時間在什麼時候, 如果發現 15 秒內都沒有任何活動就把狀態切成 offline

# 修改專案

- API

# 測試網址和方式
- 打 `POST` `https://localhost:5001/api/v1/me/devices/56/online` 
    - 檢查 56 device status 是否變成 1 
    - 檢查 db DeviceActivityLog 是否多新增一筆剛剛的紀錄
    - 15 秒後看一下 56 device status 是否變成 0



# Reviewers

@LiangYingC @vickychou99 
