### PR TITLE
hotfix: fix-oauth-client-render-loop-bug (to master)

### DIFF
--- a/dashboard/src/redux/reducers/oauth-clients.reducer.ts
+++ b/dashboard/src/redux/reducers/oauth-clients.reducer.ts
@@ -27,7 +27,7 @@ export const oauthClientsSlice = createSlice({
             if (list === null) {
                 return {
                     ...state,
-                    triggers: [newOne],
+                    oauthClients: [newOne],
                 };
             }
 


### PR DESCRIPTION
# 修改內容

發到 master hotfix。

https://github.com/miterfrants/itemhub/issues/303

- 根本原因在於 `oauthClientsSlice` 中的 `refreshOne`，並沒有把打完 API 接收的 oauthClients，正確 set 進去，導致 oauthClients 永遠是 null，進而再次觸發打 API 拿資料，造成無限循環。

# 修改專案

- Dashboard F2E

# 測試網址和方式

- 進入這個網址 [http://localhost:3000/dashboard/oauth-clients/27](http://localhost:3000/dashboard/oauth-clients/27)，重新整理頁面，不會再重複打 API 

# Reviewers

@miterfrants  @vickychou99 
