### PR TITLE
fix: 修正 Dashboard 沒辦法正常取得 API 資料

### DIFF
--- a/api/Homo.AuthApi/Filters/AuthorizeAttribute.cs
+++ b/api/Homo.AuthApi/Filters/AuthorizeAttribute.cs
@@ -44,7 +44,8 @@ namespace Homo.AuthApi
                 throw new CustomException(ERROR_CODE.UNAUTH_ACCESS_API, HttpStatusCode.Unauthorized);
             }
 
-            long? userId = JWTHelper.GetUserIdFromRequest(_jwtKey, context.HttpContext.Request);
+            var extraPayload = Newtonsoft.Json.JsonConvert.DeserializeObject<DTOs.JwtExtraPayload>(payload.FindFirstValue("extra"));
+            long? userId = extraPayload.Id;
 
             if (userId == null && isSignUp == false)
             {


### PR DESCRIPTION
# 修改內容

- 認證 Filter 取得使用者 ID 的 function 是固定拿 Cookie 中名稱為 token 的資料, 但這時候的 key 已經換成 dashbaordJwtKey 所以會發生驗證錯誤解不開 jwt 的問題

# 修改專案

- API


# 測試網址和方式

- 取得兩階段驗證, 到了 http://localhost:3000/dashboard/devices/ 看一下是否可以正常顯示列表

# Reviewers
@LiangYingC @vickychou99 
