### PR TITLE
fix: 避免已經註冊的 email 再發送驗證信件

### DIFF
--- a/api/Homo.AuthApi/Constants/Error.cs
+++ b/api/Homo.AuthApi/Constants/Error.cs
@@ -22,5 +22,6 @@ namespace Homo.AuthApi
         public static string DUPLICATED_PHONE = "DUPLICATED_PHONE";
         public static string WITHOUT_PERMISSION_TO_GET_EMAIL = "WITHOUT_PERMISSION_TO_GET_EMAIL";
         public static string ALREADY_SIGN_UP_BY_THIS_EMAIL = "ALREADY_SIGN_UP_BY_THIS_EMAIL";
+        public static string DUPLICATE_EMAIL = "DUPLICATE_EMAIL";
     }
 }

--- a/api/Homo.AuthApi/Controllers/AuthVerifyEmailController.cs
+++ b/api/Homo.AuthApi/Controllers/AuthVerifyEmailController.cs
@@ -100,6 +100,11 @@ namespace Homo.AuthApi
         [HttpPost]
         public dynamic verifyEmail([FromBody] DTOs.VerifyEmail dto)
         {
+            User user = UserDataservice.GetOneByEmail(_dbContext, dto.Email);
+            if (user != null)
+            {
+                throw new CustomException(ERROR_CODE.DUPLICATE_EMAIL, HttpStatusCode.BadRequest);
+            }
             VerifyCode record = VerifyCodeDataservice.GetOneUnUsedByEmail(_dbContext, dto.Email, dto.Code);
             if (record == null)
             {

--- a/api/Localization/Error/zh-TW.json
+++ b/api/Localization/Error/zh-TW.json
@@ -24,5 +24,7 @@
     "VERIFY_PHONE_TOKEN_EXPIRED": "驗證憑證過期, 請回上一步",
     "DUPLICATED_PHONE": "已經有人用這個手機註冊",
     "WITHOUT_PERMISSION_TO_GET_EMAIL": "無法取得 Email, 可能是你不允許我們透過社群平台讀取你的 Email",
-    "ALREADY_SIGN_UP_BY_THIS_EMAIL": "這個 Email 已經被其他使用者註冊過了, 請試著登入或是更換 Email"
+    "ALREADY_SIGN_UP_BY_THIS_EMAIL": "這個 Email 已經被其他使用者註冊過了, 請試著登入或是更換 Email",
+    "NO_SUBSCRIPTION": "目前沒有訂閱紀錄",
+    "DUPLICATE_EMAIL": "重複的 Email"
 }


### PR DESCRIPTION
# 修改內容

- Ref #329

# 修改專案

- API

# 測試網址和方式

- 跑一次註冊驗證信流程, 使用已經註冊使用者 email 

# Reviewers

@LiangYingC 
