### PR TITLE
feat: 實作依照使用者訂閱方案清除資料

### DIFF
--- a/api/Helpers/Subscription.Helper.cs
+++ b/api/Helpers/Subscription.Helper.cs
@@ -88,5 +88,26 @@ namespace Homo.IotApi
             }
             return "";
         }
+
+        public static int GetStorageSavingSeconds(PRICING_PLAN pricingPlan)
+        {
+            if (pricingPlan == PRICING_PLAN.BASIC)
+            {
+                return 6 * 60 * 60;
+            }
+            else if (pricingPlan == PRICING_PLAN.ADVANCE)
+            {
+                return 24 * 60 * 60;
+            }
+            else if (pricingPlan == PRICING_PLAN.GROWTH)
+            {
+                return 3 * 24 * 60 * 60;
+            }
+            else if (pricingPlan == PRICING_PLAN.SMALL_BUSINESS)
+            {
+                return 7 * 24 * 60 * 60;
+            }
+            return 0;
+        }
     }
 }

--- a/api/Helpers/Subscription.Helper.cs
+++ b/api/Helpers/Subscription.Helper.cs
@@ -107,7 +107,7 @@ namespace Homo.IotApi
             {
                 return 7 * 24 * 60 * 60;
             }
-            return 0;
+            return 30 * 60;
         }
     }
 }

--- a/api/Services/ClearExpiredDevicePinSensorDataCronJobService.cs
+++ b/api/Services/ClearExpiredDevicePinSensorDataCronJobService.cs
@@ -1,0 +1,60 @@
+using System;
+using Microsoft.EntityFrameworkCore;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
+using System.Collections.Generic;
+using Homo.AuthApi;
+using System.Linq;
+using System.Net.Http;
+using Newtonsoft.Json;
+using Homo.Core.Constants;
+
+namespace Homo.IotApi
+{
+    public class ClearExpiredDevicePinSensorDataCronJobService : CronJobService
+    {
+        private readonly string _envName;
+        private readonly string _dbc;
+
+        public ClearExpiredDevicePinSensorDataCronJobService(IScheduleConfig<ClearExpiredDevicePinSensorDataCronJobService> config, IServiceProvider serviceProvider, Microsoft.AspNetCore.Hosting.IWebHostEnvironment env, IOptions<AppSettings> appSettings)
+            : base(config.CronExpression, config.TimeZoneInfo, serviceProvider)
+        {
+            _envName = env.EnvironmentName;
+            _dbc = appSettings.Value.Secrets.DBConnectionString;
+        }
+
+        public override Task StartAsync(CancellationToken cancellationToken)
+        {
+            Console.WriteLine("ClearExpiredDevicePinSensorDataCronJobService starts.");
+            return base.StartAsync(cancellationToken);
+        }
+
+        public override async Task<dynamic> DoWork(CancellationToken cancellationToken)
+        {
+            Task<dynamic> task = (await recursiveDeleteDevicePinSensorData(null));
+            return task;
+        }
+
+        public async Task<dynamic> recursiveDeleteDevicePinSensorData(long? latestId)
+        {
+            DbContextOptionsBuilder<IotDbContext> iotBuilder = new DbContextOptionsBuilder<IotDbContext>();
+            var serverVersion = new MySqlServerVersion(new Version(8, 0, 25));
+            iotBuilder.UseMySql(_dbc, serverVersion);
+            IotDbContext _iotDbContext = new IotDbContext(iotBuilder.Options);
+            long? currentLatestId = DevicePinSensorDataservice.DeleteExpiredDataAndGetLatestItemId(_iotDbContext, 1, 50, latestId);
+            if (currentLatestId == null)
+            {
+                return Task.CompletedTask;
+            }
+            await Task.Delay(5 * 1000);
+            return recursiveDeleteDevicePinSensorData(currentLatestId);
+        }
+
+        public override Task StopAsync(CancellationToken cancellationToken)
+        {
+            Console.WriteLine("ClearExpiredDevicePinSensorDataCronJobService is stopping.");
+            return base.StopAsync(cancellationToken);
+        }
+    }
+}

--- a/api/Startup.cs
+++ b/api/Startup.cs
@@ -90,6 +90,12 @@ namespace Homo.IotApi
                     c.CronExpression = @"0 0 * * *";
                 });
 
+            services.AddCronJob<ClearExpiredDevicePinSensorDataCronJobService>(c =>
+                {
+                    c.TimeZoneInfo = TimeZoneInfo.Local;
+                    c.CronExpression = @"0 0 * * *";
+                });
+
             services.AddSwaggerGen(c =>
             {
                 c.SwaggerDoc("v1", new Microsoft.OpenApi.Models.OpenApiInfo() { Title = "Api Doc", Version = "v1" });


### PR DESCRIPTION
# 修改內容

- Ref #326 
- as title

# 修改專案

- API


# 測試網址和方式

- 先確認一下自己帳號所訂閱的方案, 確定資料保存時間
- 資料庫把 DeviceSensorData 複製一些資料, 並把資料的 OwnerId 改成自己, 修改 CreatedAt 把時間改在訂閱方案時刻前後
- 把 Startup.cs 
```
services.AddCronJob<ClearExpiredDevicePinSensorDataCronJobService>(c =>
                {
                    c.TimeZoneInfo = TimeZoneInfo.Local;
                    c.CronExpression = @"0 0 * * *";
                });
```
其中的 `0 0 * * *` 改成 `* * * * *` 每分鐘執行
- 跑完後檢查一下資料庫 DeviceSensorData 是否訂閱方案時刻前的資料被留著, 過期的資料被刪掉

# Reviewers

@LiangYingC @vickychou99 
