### PR TITLE
Feat/dashboard token expired

### DIFF
--- a/dashboard/src/constants/error-key.ts
+++ b/dashboard/src/constants/error-key.ts
@@ -1,0 +1,3 @@
+export const ERROR_KEY = {
+    TOKEN_EXPIRED: 'TOKEN_EXPIRED',
+};

--- a/dashboard/src/hooks/apis/fetch.hook.ts
+++ b/dashboard/src/hooks/apis/fetch.hook.ts
@@ -1,6 +1,9 @@
 import { useState, useCallback } from 'react';
 import { FetchErrorResultData } from '@/types/helpers.type';
 import { ApiHelpers } from '@/helpers/api.helper';
+import { ERROR_KEY } from '@/constants/error-key';
+import { CookieHelpers } from '@/helpers/cookie.helper';
+import { COOKIE_KEY } from '@/constants/cookie-key';
 
 export const useFetchApi = <T>({
     apiPath,
@@ -47,7 +50,15 @@ export const useFetchApi = <T>({
             const errorKey = errorData.errorKey;
 
             // TODO: can handle global error ui here, e.g. open global error modal.
-            alert(errorKey);
+            if (errorKey === ERROR_KEY.TOKEN_EXPIRED) {
+                CookieHelpers.EraseCookie({ name: COOKIE_KEY.DASHBOARD_TOKEN });
+                location.href = `${
+                    import.meta.env.VITE_WEBSITE_URL
+                }/auth/two-factor-auth/`;
+            } else {
+                alert(errorKey);
+            }
+
             // TODO: or just use error data to show on error section.
             setError(error);
         } finally {

--- a/website/src/components/header/header.component.js
+++ b/website/src/components/header/header.component.js
@@ -40,10 +40,13 @@ export class HeaderComponent extends BaseComponent {
 
     redirectToDashboard () {
         const dashboardToken = CookieUtil.getCookie('dashboardToken');
+        const payload = window.jwt_decode(dashboardToken);
+        const nowUnixTimestamp = new Date() / 1000;
+        const validatedDashboardToken = payload.exp >= nowUnixTimestamp;
         const token = CookieUtil.getCookie('token');
-        if (token && dashboardToken) {
+        if (token && dashboardToken && validatedDashboardToken) {
             location.href = APP_CONFIG.DASHBOARD_URL;
-        } else if (token && !dashboardToken) {
+        } else if (token && (!dashboardToken || !validatedDashboardToken)) {
             history.pushState({}, '', '/auth/two-factor-auth/');
         } else if (!token) {
             history.replaceState({}, '', `/auth/sign-in/?redirectUrl=${encodeURIComponent('/auth/two-factor-auth/')}`);


### PR DESCRIPTION
# 修改內容

- Ref https://github.com/miterfrants/itemhub/issues/367
- dashboard API 回 TOKEN_EXPIRED 把 dashboardToken 清除和 redirect website
- website 前端檢查 dashboardToken 是否過期, 如果過期就重新跑一次 two-factory-auth

# 修改專案

- Dashboard F2E
- Website F2E

# 測試網址和方式
## Website
- 先產生一個比較容易過期的 dashboardToken
- https://dev.itemhub.io/ 點擊 header 的 dashboard link 看過期的 dashboardToken 會不會再跑一次 two-factory-auth

## Dashboard 
- 產生一個比較容易過期的 dashboardToken
- 後台切換 router 檢查會不會自動被導回 website two-factory-auth 流程

# Reviewers
@LiangYingC @vickychou99 
