### PR TITLE
feat: add swagger ui for client

### DIFF
--- a/api/Controllers/CheckoutController.cs
+++ b/api/Controllers/CheckoutController.cs
@@ -12,6 +12,7 @@ using Newtonsoft.Json;
 namespace Homo.IotApi
 {
     [Route("v1/checkout")]
+    [SwaggerUiInvisibility]
     [AuthorizeFactory()]
     public class CheckoutController : ControllerBase
     {

--- a/api/Controllers/ContactController.cs
+++ b/api/Controllers/ContactController.cs
@@ -8,8 +8,9 @@ using System.Threading.Tasks;
 
 namespace Homo.IotApi
 {
-    [IotAuthorizeFactory]
     [Route("v1/contact")]
+    [SwaggerUiInvisibility]
+    [IotAuthorizeFactory]
     [Validate]
     public class ContactController : ControllerBase
     {

--- a/api/Controllers/MyDeviceController.cs
+++ b/api/Controllers/MyDeviceController.cs
@@ -12,8 +12,8 @@ using Homo.Core.Constants;
 
 namespace Homo.IotApi
 {
+    [Route("v1/my/devices")]
     [IotDashboardAuthorizeFactory]
-    [Route("v1/me/devices")]
     [Validate]
     public class MyDeviceController : ControllerBase
     {

--- a/api/Controllers/MyDevicePinController.cs
+++ b/api/Controllers/MyDevicePinController.cs
@@ -8,8 +8,8 @@ using System.Linq;
 
 namespace Homo.IotApi
 {
+    [Route("v1/my/devices/{id}/pins")]
     [IotDashboardAuthorizeFactory]
-    [Route("v1/me/devices/{id}/pins")]
     [Validate]
     public class MyDevicePinController : ControllerBase
     {

--- a/api/Controllers/MyDevicePinSensorController.cs
+++ b/api/Controllers/MyDevicePinSensorController.cs
@@ -5,8 +5,8 @@ using Homo.Core.Constants;
 
 namespace Homo.IotApi
 {
+    [Route("v1/my/devices/{id}/sensors")]
     [IotDashboardAuthorizeFactory]
-    [Route("v1/me/devices/{id}/sensors")]
     [Validate]
     public class MyDevicePinSensorController : ControllerBase
     {

--- a/api/Controllers/MyDevicePinSwitchController.cs
+++ b/api/Controllers/MyDevicePinSwitchController.cs
@@ -5,8 +5,8 @@ using Homo.Core.Constants;
 
 namespace Homo.IotApi
 {
+    [Route("v1/my/devices/{id}/switches")]
     [IotDashboardAuthorizeFactory]
-    [Route("v1/me/devices/{id}/switches")]
     [Validate]
     public class MyDeviceSwitchController : ControllerBase
     {

--- a/api/Controllers/MyOauthClientController.cs
+++ b/api/Controllers/MyOauthClientController.cs
@@ -6,8 +6,8 @@ using Homo.Core.Helpers;
 
 namespace Homo.IotApi
 {
+    [Route("v1/my/oauth-clients")]
     [IotDashboardAuthorizeFactory]
-    [Route("v1/me/oauth-clients")]
     [Validate]
     public class OauthClientController : ControllerBase
     {

--- a/api/Controllers/MyOauthClientRedirectUriController.cs
+++ b/api/Controllers/MyOauthClientRedirectUriController.cs
@@ -5,8 +5,8 @@ using Homo.Core.Constants;
 
 namespace Homo.IotApi
 {
+    [Route("v1/my/oauth-client-redirect-uris")]
     [IotDashboardAuthorizeFactory]
-    [Route("v1/me/oauth-client-redirect-uris")]
     [Validate]
     public class OauthClientRedirectUriController : ControllerBase
     {

--- a/api/Controllers/MySubscriptionController.cs
+++ b/api/Controllers/MySubscriptionController.cs
@@ -8,8 +8,9 @@ using System.Threading.Tasks;
 
 namespace Homo.IotApi
 {
-    [IotAuthorizeFactory]
     [Route("v1/my/subscription")]
+    [SwaggerUiInvisibility]
+    [IotAuthorizeFactory]
     [Validate]
     public class MySubscriptionController : ControllerBase
     {

--- a/api/Controllers/MyTransactionController.cs
+++ b/api/Controllers/MyTransactionController.cs
@@ -8,8 +8,9 @@ using System.Linq;
 
 namespace Homo.IotApi
 {
-    [IotAuthorizeFactory]
     [Route("v1/my/transaction/{id}")]
+    [SwaggerUiInvisibility]
+    [IotAuthorizeFactory]
     [Validate]
     public class MyTransactionController : ControllerBase
     {

--- a/api/Controllers/MyTriggerController.cs
+++ b/api/Controllers/MyTriggerController.cs
@@ -6,7 +6,7 @@ using Homo.Core.Constants;
 namespace Homo.IotApi
 {
     [IotDashboardAuthorizeFactory]
-    [Route("v1/me/triggers")]
+    [Route("v1/my/triggers")]
     [Validate]
     public class TriggerController : ControllerBase
     {

--- a/api/Controllers/MyZoneController.cs
+++ b/api/Controllers/MyZoneController.cs
@@ -5,8 +5,9 @@ using Homo.Core.Constants;
 
 namespace Homo.IotApi
 {
+    [Route("v1/my/zones")]
+    [SwaggerUiInvisibility]
     [IotAuthorizeFactory]
-    [Route("v1/me/zones")]
     [Validate]
     public class MyZoneController : ControllerBase
     {

--- a/api/Controllers/TappayController.cs
+++ b/api/Controllers/TappayController.cs
@@ -9,6 +9,7 @@ using System.Linq;
 namespace Homo.IotApi
 {
     [Route("v1/tappay")]
+    [SwaggerUiInvisibility]
     [Validate]
     public class TappayController : ControllerBase
     {

--- a/api/Controllers/UniversalController.cs
+++ b/api/Controllers/UniversalController.cs
@@ -2,10 +2,12 @@ using Microsoft.AspNetCore.Mvc;
 using Homo.AuthApi;
 using System.Collections.Generic;
 using System.Linq;
+using Homo.Api;
 
 namespace Homo.IotApi
 {
     [Route("v1/universal")]
+    [SwaggerUiInvisibility]
     public class IotUniversalController : ControllerBase
     {
 

--- a/api/Controllers/UserController.cs
+++ b/api/Controllers/UserController.cs
@@ -2,10 +2,12 @@
 using Homo.AuthApi;
 using Homo.Core.Constants;
 using Homo.Core.Helpers;
+using Homo.Api;
 
 namespace Homo.IotApi
 {
     [Route("v1/users")]
+    [SwaggerUiInvisibility]
     public class UserController : ControllerBase
     {
         private readonly DBContext _dbContext;

--- a/api/Homo.Api/Controllers/TestController.cs
+++ b/api/Homo.Api/Controllers/TestController.cs
@@ -4,6 +4,7 @@ using Homo.Core.Constants;
 namespace Homo.Api
 {
     [Route("v1/test")]
+    [SwaggerUiInvisibility]
     public class TestController : ControllerBase
     {
         public TestController(Microsoft.AspNetCore.Hosting.IWebHostEnvironment env)

--- a/api/Homo.Api/Controllers/TestLocalController.cs
+++ b/api/Homo.Api/Controllers/TestLocalController.cs
@@ -4,6 +4,7 @@ using Homo.Core.Constants;
 namespace Homo.Api
 {
     [Route("v1/localization")]
+    [SwaggerUiInvisibility]
     public class TestLocalController
     {
         private CommonLocalizer _commonLocalizer;

--- a/api/Homo.Api/Filters/SwaggerUiInvisibilityAttribute.cs
+++ b/api/Homo.Api/Filters/SwaggerUiInvisibilityAttribute.cs
@@ -1,0 +1,20 @@
+using System;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+
+
+namespace Homo.Api
+{
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class)]
+    public class SwaggerUiInvisibilityAttribute : ApiExplorerSettingsAttribute
+    {
+        public SwaggerUiInvisibilityAttribute()
+        {
+            if (EnvService.Get().EnvironmentName != "dev")
+            {
+                IgnoreApi = true;
+            }
+        }
+    }
+}

--- a/api/Homo.Api/Services/EnvService.cs
+++ b/api/Homo.Api/Services/EnvService.cs
@@ -1,0 +1,17 @@
+using Microsoft.AspNetCore.Hosting;
+
+namespace Homo.Api
+{
+    public static class EnvService
+    {
+        public static IWebHostEnvironment _env;
+        public static void Set(IWebHostEnvironment env)
+        {
+            _env = env;
+        }
+        public static IWebHostEnvironment Get()
+        {
+            return _env;
+        }
+    }
+}

--- a/api/Homo.AuthApi/Controllers/AuthIsSignInController.cs
+++ b/api/Homo.AuthApi/Controllers/AuthIsSignInController.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
+using Homo.Api;
 
 namespace Homo.AuthApi
 {
@@ -17,6 +18,7 @@ namespace Homo.AuthApi
         }
 
         [Route("is-sign-in")]
+        [SwaggerUiInvisibility]
         [HttpPost]
         public dynamic isSignIn()
         {

--- a/api/Homo.AuthApi/Controllers/AuthRemoveFbSubController.cs
+++ b/api/Homo.AuthApi/Controllers/AuthRemoveFbSubController.cs
@@ -5,12 +5,14 @@ using System;
 using System.Text;
 using Homo.Core.Constants;
 using Homo.Core.Helpers;
+using Homo.Api;
 
 namespace Homo.AuthApi
 {
 
 
     [Route("v1/auth/fb-sub")]
+    [SwaggerUiInvisibility]
     public class AuthRemoveFbSubController : ControllerBase
     {
 

--- a/api/Homo.AuthApi/Controllers/AuthResetPasswordController.cs
+++ b/api/Homo.AuthApi/Controllers/AuthResetPasswordController.cs
@@ -11,6 +11,7 @@ using System.Security.Claims;
 namespace Homo.AuthApi
 {
     [Route("v1/auth")]
+    [SwaggerUiInvisibility]
     public class AuthResetPasswordController : ControllerBase
     {
 

--- a/api/Homo.AuthApi/Controllers/AuthSignInController.cs
+++ b/api/Homo.AuthApi/Controllers/AuthSignInController.cs
@@ -10,6 +10,7 @@ using Homo.Api;
 namespace Homo.AuthApi
 {
     [Route("v1/auth")]
+    [SwaggerUiInvisibility]
     public class AuthSignInController : ControllerBase
     {
 

--- a/api/Homo.AuthApi/Controllers/AuthSignUpController.cs
+++ b/api/Homo.AuthApi/Controllers/AuthSignUpController.cs
@@ -8,10 +8,12 @@ using Microsoft.Extensions.Options;
 
 using Homo.Core.Constants;
 using Homo.Core.Helpers;
+using Homo.Api;
 
 namespace Homo.AuthApi
 {
     [Route("v1/auth")]
+    [SwaggerUiInvisibility]
     [Homo.Api.Validate]
     public class AuthSignUpController : ControllerBase
     {

--- a/api/Homo.AuthApi/Controllers/AuthTwoFactorController.cs
+++ b/api/Homo.AuthApi/Controllers/AuthTwoFactorController.cs
@@ -3,10 +3,12 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
 using Homo.Core.Constants;
 using Homo.Core.Helpers;
+using Homo.Api;
 
 namespace Homo.AuthApi
 {
     [Route("v1/auth")]
+    [SwaggerUiInvisibility]
     [AuthorizeFactory()]
     public class AuthTwoFactorController : ControllerBase
     {

--- a/api/Homo.AuthApi/Controllers/AuthUpdateEarlyBirdController.cs
+++ b/api/Homo.AuthApi/Controllers/AuthUpdateEarlyBirdController.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.Options;
 
 using Homo.Core.Constants;
 using Homo.Core.Helpers;
+using Homo.Api;
 
 namespace Homo.AuthApi
 {
@@ -37,6 +38,7 @@ namespace Homo.AuthApi
         }
 
         [Route("register-for-early-bird")]
+        [SwaggerUiInvisibility]
         [AuthorizeFactory(AUTH_TYPE.SIGN_UP)]
         [HttpPost]
         public ActionResult<dynamic> registerForEarlyBird([FromBody] DTOs.SignUp dto, DTOs.JwtExtraPayload extraPayload)

--- a/api/Homo.AuthApi/Controllers/AuthVerifyEmailController.cs
+++ b/api/Homo.AuthApi/Controllers/AuthVerifyEmailController.cs
@@ -8,10 +8,12 @@ using Microsoft.Extensions.Options;
 
 using Homo.Core.Constants;
 using Homo.Core.Helpers;
+using Homo.Api;
 
 namespace Homo.AuthApi
 {
     [Route("v1/auth")]
+    [SwaggerUiInvisibility]
     [Homo.Api.Validate]
     public class AuthVerifyEmailController : ControllerBase
     {

--- a/api/Homo.AuthApi/Controllers/AuthVerifyPhoneController.cs
+++ b/api/Homo.AuthApi/Controllers/AuthVerifyPhoneController.cs
@@ -14,6 +14,7 @@ using Homo.Api;
 namespace Homo.AuthApi
 {
     [Route("v1/auth")]
+    [SwaggerUiInvisibility]
     [Homo.Api.Validate]
 
     public class AuthVerifyPhoneController : ControllerBase

--- a/api/Homo.AuthApi/Controllers/GroupController.cs
+++ b/api/Homo.AuthApi/Controllers/GroupController.cs
@@ -1,10 +1,12 @@
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Mvc;
 using Homo.Core.Constants;
+using Homo.Api;
 
 namespace Homo.AuthApi
 {
     [Route("v1/groups")]
+    [SwaggerUiInvisibility]
     [AuthorizeFactory(AUTH_TYPE.COMMON, new ROLE[] { ROLE.USER })]
     public class GroupController : ControllerBase
     {

--- a/api/Homo.AuthApi/Controllers/MeController.cs
+++ b/api/Homo.AuthApi/Controllers/MeController.cs
@@ -1,8 +1,10 @@
 using Microsoft.AspNetCore.Mvc;
+using Homo.Api;
 
 namespace Homo.AuthApi
 {
     [Route("v1/me")]
+    [SwaggerUiInvisibility]
     [AuthorizeFactory]
     public class MeController : ControllerBase
     {

--- a/api/Homo.AuthApi/Controllers/MeResetPasswordController.cs
+++ b/api/Homo.AuthApi/Controllers/MeResetPasswordController.cs
@@ -3,10 +3,12 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
 using Homo.Core.Constants;
 using Homo.Core.Helpers;
+using Homo.Api;
 
 namespace Homo.AuthApi
 {
     [Route("v1/me/reset-password")]
+    [SwaggerUiInvisibility]
     [AuthorizeFactory]
     public class MeResetPasswordController : ControllerBase
     {

--- a/api/Homo.AuthApi/Controllers/MeUpdteInfoController.cs
+++ b/api/Homo.AuthApi/Controllers/MeUpdteInfoController.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.Options;
 namespace Homo.AuthApi
 {
     [Route("v1/me")]
+    [SwaggerUiInvisibility]
     [AuthorizeFactory]
     public class MeUpdateInfoController : ControllerBase
     {

--- a/api/Homo.AuthApi/Controllers/UniversalController.cs
+++ b/api/Homo.AuthApi/Controllers/UniversalController.cs
@@ -1,8 +1,10 @@
 using Microsoft.AspNetCore.Mvc;
+using Homo.Api;
 
 namespace Homo.AuthApi
 {
     [Route("v1/universal")]
+    [SwaggerUiInvisibility]
     public class UniversalController : ControllerBase
     {
 

--- a/api/Homo.AuthApi/Controllers/UserController.cs
+++ b/api/Homo.AuthApi/Controllers/UserController.cs
@@ -2,10 +2,12 @@ using Microsoft.AspNetCore.Mvc;
 using System.Collections.Generic;
 using System.Linq;
 using Homo.Core.Constants;
+using Homo.Api;
 
 namespace Homo.AuthApi
 {
     [Route("v1/users")]
+    [SwaggerUiInvisibility]
     [AuthorizeFactory(AUTH_TYPE.COMMON, new ROLE[] { ROLE.USER })]
     public class UserController : ControllerBase
     {

--- a/api/Homo.AuthApi/Controllers/UserGroupsController.cs
+++ b/api/Homo.AuthApi/Controllers/UserGroupsController.cs
@@ -2,10 +2,12 @@ using Microsoft.AspNetCore.Mvc;
 using System.Collections.Generic;
 using System.Linq;
 using Homo.Core.Constants;
+using Homo.Api;
 
 namespace Homo.AuthApi
 {
     [Route("v1/users/{id}/groups")]
+    [SwaggerUiInvisibility]
     [AuthorizeFactory(AUTH_TYPE.COMMON, new ROLE[] { ROLE.USER })]
     public class UserGroupsController : ControllerBase
     {

--- a/api/Properties/launchSettings.json
+++ b/api/Properties/launchSettings.json
@@ -17,6 +17,15 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "dev"
       }
+    },
+    "prod": {
+      "commandName": "Project",
+      "applicationUrl": "https://localhost:5001;http://localhost:5000",
+      "launchBrowser": true,
+      "launchUrl": "swagger/index.html",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "prod"
+      }
     }
   }
 }

--- a/api/Startup.cs
+++ b/api/Startup.cs
@@ -32,6 +32,7 @@ namespace Homo.IotApi
                 .AddJsonFile(secretsFilename, optional: true)
                 .AddEnvironmentVariables();
             Configuration = builder.Build();
+            EnvService.Set(env);
         }
 
         public IConfiguration Configuration { get; }
@@ -75,6 +76,7 @@ namespace Homo.IotApi
             var secrets = (Homo.IotApi.Secrets)appSettings.Secrets;
             services.AddDbContext<IotDbContext>(options => options.UseMySql(secrets.DBConnectionString, serverVersion));
             services.AddDbContext<Homo.AuthApi.DBContext>(options => options.UseMySql(secrets.DBConnectionString, serverVersion));
+
             services.AddControllers();
             if (_env.EnvironmentName.ToLower() != "dev")
             {
@@ -133,12 +135,9 @@ namespace Homo.IotApi
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         {
-            if (env.EnvironmentName == "dev")
-            {
-                app.UseDeveloperExceptionPage();
-                app.UseSwagger();
-                app.UseSwaggerUI(c => c.SwaggerEndpoint("/swagger/v1/swagger.json", "homo auth api v1"));
-            }
+            app.UseDeveloperExceptionPage();
+            app.UseSwagger();
+            app.UseSwaggerUI(c => c.SwaggerEndpoint("/swagger/v1/swagger.json", "itemhub api v1"));
 
             var supportedCultures = new[] {
                 new CultureInfo("zh-TW"),

--- a/dashboard/src/constants/api.ts
+++ b/dashboard/src/constants/api.ts
@@ -3,16 +3,16 @@ export const API_URL = import.meta.env.VITE_API_URL;
 export const END_POINT = {
     SIGN_WITH_EMAIL: 'auth/sign-in-with-email',
     IS_SIGNED: 'auth/is-sign-in',
-    DEVICES: 'me/devices',
-    DEVICE: 'me/devices/:id',
-    DEVICE_PINS: 'me/devices/:id/pins',
-    DEVICE_SWITCH_PIN: 'me/devices/:id/switches/:pin',
-    DEVICE_PIN: 'me/devices/:id/pins/:pin',
-    OAUTH_CLIENTS: 'me/oauth-clients',
-    OAUTH_CLIENT: 'me/oauth-clients/:id',
-    OAUTH_CLIENT_REVOKE_SECRET: 'me/oauth-clients/:id/revoke-secret',
-    TRIGGERS: 'me/triggers',
-    TRIGGER: 'me/triggers/:id',
+    DEVICES: 'my/devices',
+    DEVICE: 'my/devices/:id',
+    DEVICE_PINS: 'my/devices/:id/pins',
+    DEVICE_SWITCH_PIN: 'my/devices/:id/switches/:pin',
+    DEVICE_PIN: 'my/devices/:id/pins/:pin',
+    OAUTH_CLIENTS: 'my/oauth-clients',
+    OAUTH_CLIENT: 'my/oauth-clients/:id',
+    OAUTH_CLIENT_REVOKE_SECRET: 'my/oauth-clients/:id/revoke-secret',
+    TRIGGERS: 'my/triggers',
+    TRIGGER: 'my/triggers/:id',
 };
 
 export const HTTP_METHOD = {


### PR DESCRIPTION
# 修改內容

- Ref #322 
- 加上 swagger ui visibility filter, 在正式環境隱藏一般使用者不需要看到的 api endpoint

# 修改專案

- API

# 測試網址和方式
- terminal `dotnet watch run --launch-profile dev" 測試環境會顯示所有 API, `dotnet watch run --launch-profile prod" 只顯示使用者相關的 API endpoints
  - GoogleSmartHome
  - MyDevice
  - MyDevicePin
  - MyDevicePinSensor
  - MyDeviceSwitch
  - Oauth
  - OauthClient
  - OauthClientRedirectUri
  - Trigger

# Reviewers

@LiangYingC @vickychou99 
