### PR TITLE
feat: oauth-client 修改成允許使用者傳空的 clientId 和避免同一個 deviceId 有多個 client

### DIFF
--- a/api/Constants/Error.cs
+++ b/api/Constants/Error.cs
@@ -10,6 +10,7 @@ namespace Homo.IotApi
         public static string TAPPAY_TRANSACTION_ERROR = "TAPPAY_TRANSACTION_ERROR";
         public static string DUPLICATE_SUBSCRIBE = "DUPLICATE_SUBSCRIBE";
         public static string DUPLICATE_OAUTH_CLIENT_ID = "DUPLICATE_OAUTH_CLIENT_ID";
+        public static string DEVICE_OAUTH_CLIENT_EXISTS = "DEVICE_OAUTH_CLIENT_EXISTS";
         public static string NO_SUBSCRIPTION = "NO_SUBSCRIPTION";
         public static string OAUTH_CLIENT_SECRET_ERROR = "OAUTH_CLIENT_SECRET_ERROR";
         public static string TOO_MANY_REQUEST = "TOO_MANY_REQUEST";

--- a/api/Dataservices/OauthClientDataservice.cs
+++ b/api/Dataservices/OauthClientDataservice.cs
@@ -22,22 +22,26 @@ namespace Homo.IotApi
                 .ToList();
         }
 
-        public static List<OauthClient> GetAll(IotDbContext dbContext, long ownerId)
+        public static List<OauthClient> GetAll(IotDbContext dbContext, long ownerId, bool isDeviceClient, long? deviceId)
         {
             return dbContext.OauthClient
                 .Where(x =>
                     x.DeletedAt == null
                     && x.OwnerId == ownerId
+                    && (isDeviceClient == false && x.DeviceId == null)
+                    && (deviceId == null && x.DeviceId == deviceId)
                 )
                 .OrderByDescending(x => x.Id)
                 .ToList();
         }
-        public static int GetRowNum(IotDbContext dbContext, long ownerId)
+        public static int GetRowNum(IotDbContext dbContext, long ownerId, bool isDeviceClient, long? deviceId)
         {
             return dbContext.OauthClient
                 .Where(x =>
                     x.DeletedAt == null
                     && x.OwnerId == ownerId
+                    && (isDeviceClient == false && x.DeviceId == null)
+                    && (deviceId == null && x.DeviceId == deviceId)
                 )
                 .Count();
         }

--- a/api/Localization/Error/zh-TW.json
+++ b/api/Localization/Error/zh-TW.json
@@ -30,5 +30,6 @@
     "DUPLICATE_OAUTH_CLIENT_ID": "這個 oAuth Client Id 已經有人使用過了, 請重新輸入",
     "NO_SUBSCRIPTION": "目前沒有訂閱紀錄",
     "DUPLICATE_EMAIL": "重複的 Email",
-    "TOO_MANY_REQUEST": "送 Request 頻率太高, 已經超越你所訂閱的方案"
+    "TOO_MANY_REQUEST": "送 Request 頻率太高, 已經超越你所訂閱的方案",
+    "DEVICE_OAUTH_CLIENT_EXISTS": "你新增的 Client 已經存在, 請先將裝置的 Client 刪除再重新新增"
 }

--- a/api/Models/DTOs/OauthClient.cs
+++ b/api/Models/DTOs/OauthClient.cs
@@ -7,7 +7,6 @@ namespace Homo.IotApi
     {
         public partial class OauthClient : DTOs
         {
-            [Required]
             [MaxLength(128)]
             public string ClientId { get; set; }
 


### PR DESCRIPTION
# 修改內容

- as title

# 修改專案

- API

# 測試網址和方式

- 試著打 `v1/my/oauth-clients` POST 不傳任何參數是否可以正常建立
- 同上一個 API 位置, 相同 deviceId 看是否在新增第二次會發生錯誤提醒

# Reviewers

@LiangYingC @vickychou99 
