### PR TITLE
Refactor/use ref to handle has devices stiuation

### DIFF
--- a/dashboard/src/pages/devices/devices.tsx
+++ b/dashboard/src/pages/devices/devices.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useRef, useEffect, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { useQuery } from '@/hooks/query.hook';
 import { useAppSelector } from '@/hooks/redux.hook';
@@ -19,11 +19,12 @@ const Devices = () => {
     const query = useQuery();
     const page = Number(query.get('page') || 1);
     const limit = Number(query.get('limit') || 10);
+
     const [deviceName, setDeviceName] = useState(query.get('deviceName') || '');
     const devicesState = useAppSelector(selectDevices);
+    const hasDevicesRef = useRef(false);
     const devices = devicesState.devices;
     const rowNum = devicesState.rowNum;
-    const countOfAllDevices = devicesState.countOfAllDevices;
 
     const navigate = useNavigate();
     let shouldBeTwiceEnter = false;
@@ -36,8 +37,14 @@ const Devices = () => {
     });
 
     useEffect(() => {
+        if (devices && devices.length > 0) {
+            hasDevicesRef.current = true;
+        }
+    }, [devices]);
+
+    useEffect(() => {
         getDevicesApi();
-    }, [page]);
+    }, [getDevicesApi]);
 
     const refresh = () => {
         getDevicesApi();
@@ -106,7 +113,7 @@ const Devices = () => {
                     <>
                         <div
                             className={`${
-                                countOfAllDevices === 0 ? 'd-block' : 'd-none'
+                                hasDevicesRef.current ? 'd-none' : 'd-block'
                             } p-6 text-center`}
                         >
                             <img src={emptyImage} alt="" />
@@ -125,7 +132,7 @@ const Devices = () => {
                         </div>
                         <div
                             className={`${
-                                countOfAllDevices > 0 ? 'd-block' : 'd-none'
+                                hasDevicesRef.current ? 'd-block' : 'd-none'
                             }`}
                         >
                             <div className="mt-3 mt-sm-45">

--- a/dashboard/src/redux/reducers/devices.reducer.ts
+++ b/dashboard/src/redux/reducers/devices.reducer.ts
@@ -5,13 +5,11 @@ import { DeviceItem } from '@/types/devices.type';
 type DeviceState = {
     devices: DeviceItem[] | null;
     rowNum: number;
-    countOfAllDevices: number;
 };
 
 const initialState: DeviceState = {
     devices: null,
     rowNum: 0,
-    countOfAllDevices: 0,
 };
 
 export const devicesSlice = createSlice({
@@ -19,13 +17,7 @@ export const devicesSlice = createSlice({
     initialState: initialState,
     reducers: {
         refresh: (state, action: PayloadAction<DeviceState>) => {
-            return {
-                ...action.payload,
-                countOfAllDevices:
-                    state.countOfAllDevices === 0
-                        ? action.payload.rowNum
-                        : state.countOfAllDevices,
-            };
+            return action.payload;
         },
         append: (state, action: PayloadAction<DeviceItem>) => {
             const deviceInState = state.devices?.find(
@@ -67,8 +59,6 @@ export const devicesSlice = createSlice({
             if (devices === null) {
                 throw new Error('Can not updateDevice when devices is null.');
             }
-
-            // todo: reduce countOfAllDevices in this sitituation
 
             return {
                 ...state,


### PR DESCRIPTION
# 修改內容

先前是用 devices.redux 裡面多存一個 countOfAllDevices 去判斷裝置列表是否有裝置的狀況，但目前 redux 資料通常是用來處理跨頁面的情境(例如：device 頁面需要拿到 devices 頁面資料)，如果在同一個頁面存資料，可以用 ref 解決即可，維護上也比較不會複雜。

如 commits :
- refactor: 使用 ref 紀錄是否有裝置，假定有裝置，則為 true
- refactor: 拔掉已經不需要的 countOfAllDevices

# 修改專案

- Dashboard F2E

# 測試網址和方式

- 如果完全沒有過 devices 資料，會顯示新增裝置的提示
- 如果有過 devices 資料，就不會顯示新增裝置的提示（即便搜尋結果為 0）

# Reviewers

@miterfrants @vickychou99 
