### PR TITLE
 fix: 修正按鈕和 tag 斷行

### DIFF
--- a/dashboard/src/css/button.scss
+++ b/dashboard/src/css/button.scss
@@ -48,6 +48,7 @@
     align-items: center;
     border-radius: 50rem;
     box-shadow: $btn-box-shadow;
+    white-space: nowrap;
 
     .icon {
         padding-right: 0.5rem;

--- a/dashboard/src/css/tag.scss
+++ b/dashboard/src/css/tag.scss
@@ -13,6 +13,7 @@ $tag-colors: (
     position: relative;
     padding: 0.3125rem 0.75rem;
     line-height: 1;
+    white-space: nowrap;
 
     &:before {
         display: inline-block;


### PR DESCRIPTION
# 修改內容

- 修正按鈕斷行問題
<img width="529" alt="截圖 2022-05-06 下午1 55 41" src="https://user-images.githubusercontent.com/2028693/167075120-bc292818-a4b4-4430-967a-f2ac5e9b57d9.png">
- 修正裝置狀態斷行問題
<img src="https://user-images.githubusercontent.com/2028693/167075473-ed9378d6-e084-47e1-ab99-7be8226b746b.jpg" />


# 修改專案

- Dashboard F2E

# 測試網址和方式
- 按鈕斷行可以參考上面圖片
- 裝置狀態斷行需要用手機連到或是等上了測試機再測試

# Reviewers

@LiangYingC @vickychou99 
