### PR TITLE
Feat/add online status tag to triggers

### DIFF
--- a/dashboard/src/components/online-status-tag/online-status-tag.tsx
+++ b/dashboard/src/components/online-status-tag/online-status-tag.tsx
@@ -1,0 +1,9 @@
+const OnlineSatusTag = ({ isOnline }: { isOnline: boolean }) => {
+    return (
+        <div className={`tag fs-5 ${isOnline ? 'tag-green' : 'tag-grey'}`}>
+            <div>{isOnline ? '上線' : '離線'}</div>
+        </div>
+    );
+};
+
+export default OnlineSatusTag;

--- a/dashboard/src/pages/device/device.tsx
+++ b/dashboard/src/pages/device/device.tsx
@@ -1,3 +1,4 @@
+import moment from 'moment';
 import { useRef, useState, useEffect } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import {
@@ -10,19 +11,19 @@ import { useDownloadFirmwareApi } from '@/hooks/apis/firmware.hook';
 import { useAppSelector } from '@/hooks/redux.hook';
 import { selectDevices } from '@/redux/reducers/devices.reducer';
 import Pins from '@/components/pins/pins';
-import { RESPONSE_STATUS } from '@/constants/api';
 import PageTitle from '@/components/page-title/page-title';
+import OnlineStatusTag from '@/components/online-status-tag/online-status-tag';
+import { RESPONSE_STATUS } from '@/constants/api';
 import { useDispatch } from 'react-redux';
 import { dialogActions, DialogTypeEnum } from '@/redux/reducers/dialog.reducer';
-import trashIcon from '@/assets/images/trash.svg';
+import { selectUniversal } from '@/redux/reducers/universal.reducer';
 import {
     toasterActions,
     ToasterTypeEnum,
 } from '@/redux/reducers/toaster.reducer';
-import moment from 'moment';
+import trashIcon from '@/assets/images/trash.svg';
 import cloudIcon from '@/assets/images/cloud.svg';
 import compassIcon from '@/assets/images/compass.svg';
-import { selectUniversal } from '@/redux/reducers/universal.reducer';
 
 const Device = () => {
     const { id: idFromUrl } = useParams();
@@ -234,13 +235,7 @@ const Device = () => {
                                 狀態
                             </div>
                             <div className="py-2 px-25">
-                                <div
-                                    className={`tag fs-5 ${
-                                        device.online ? 'tag-green' : 'tag-grey'
-                                    }`}
-                                >
-                                    <div>{device.online ? '上線' : '離線'}</div>
-                                </div>
+                                <OnlineStatusTag isOnline={device.online} />
                             </div>
                         </div>
                         <div className="col-12 col-lg-6 d-flex p-0 item">

--- a/dashboard/src/pages/devices/devices.tsx
+++ b/dashboard/src/pages/devices/devices.tsx
@@ -21,9 +21,10 @@ import { RESPONSE_STATUS } from '@/constants/api';
 import { useDownloadFirmwareApi } from '@/hooks/apis/firmware.hook';
 import compassIcon from '@/assets/images/compass.svg';
 import stopIcon from '@/assets/images/stop.svg';
-import { dialogActions, DialogTypeEnum } from '@/redux/reducers/dialog.reducer';
 import { useDispatch } from 'react-redux';
+import { dialogActions, DialogTypeEnum } from '@/redux/reducers/dialog.reducer';
 import ReactTooltip from 'react-tooltip';
+import OnlineStatusTag from '@/components/online-status-tag/online-status-tag';
 import Spinner from '@/components/spinner/spinner';
 
 const Devices = () => {
@@ -241,19 +242,9 @@ const Devices = () => {
                                                     狀態
                                                 </div>
                                                 <div className="col-8 col-lg-2 p-3 p-lg-0">
-                                                    <div
-                                                        className={`tag fs-5 ${
-                                                            online
-                                                                ? 'tag-green'
-                                                                : 'tag-grey'
-                                                        }`}
-                                                    >
-                                                        <div>
-                                                            {online
-                                                                ? '上線'
-                                                                : '離線'}
-                                                        </div>
-                                                    </div>
+                                                    <OnlineStatusTag
+                                                        isOnline={online}
+                                                    />
                                                 </div>
                                                 <div className="col-4 d-lg-none bg-black bg-opacity-5 text-black text-opacity-45 p-3">
                                                     建立時間

--- a/dashboard/src/pages/triggers/triggers.tsx
+++ b/dashboard/src/pages/triggers/triggers.tsx
@@ -14,18 +14,18 @@ import {
     ToasterTypeEnum,
 } from '@/redux/reducers/toaster.reducer';
 import { ArrayHelpers } from '@/helpers/array.helper';
-import { TriggerItem } from '@/types/triggers.type';
+import ReactTooltip from 'react-tooltip';
 import Pagination from '@/components/pagination/pagination';
 import PageTitle from '@/components/page-title/page-title';
 import { dialogActions, DialogTypeEnum } from '@/redux/reducers/dialog.reducer';
 import SearchInput from '@/components/inputs/search-input/search-input';
 import AutocompletedSearch from '@/components/inputs/autocompleted-search/autocompleted-search';
 import EmptyDataToCreateItem from '@/components/empty-data-to-create-item/empty-data-to-create-item';
+import OnlineStatusTag from '@/components/online-status-tag/online-status-tag';
+import Spinner from '@/components/spinner/spinner';
 import lightTrashIcon from '@/assets/images/light-trash.svg';
 import pencilIcon from '@/assets/images/pencil.svg';
 import trashIcon from '@/assets/images/trash.svg';
-import ReactTooltip from 'react-tooltip';
-import Spinner from '@/components/spinner/spinner';
 
 const Triggers = () => {
     const navigate = useNavigate();
@@ -371,6 +371,14 @@ const Triggers = () => {
                                                 </div>
                                                 <div className="col-8 col-lg-2 py-3 py-lg-0 lh-base">
                                                     {sourceDevice?.name}
+                                                    <div className="mt-2">
+                                                        <OnlineStatusTag
+                                                            isOnline={
+                                                                sourceDevice?.online ||
+                                                                false
+                                                            }
+                                                        />
+                                                    </div>
                                                 </div>
                                                 <div className="d-block d-lg-none col-4 py-3 bg-black bg-opacity-5 text-black text-opacity-45">
                                                     來源 Pin
@@ -398,6 +406,14 @@ const Triggers = () => {
                                                 </div>
                                                 <div className="col-8 col-lg-2 lh-base py-3 py-lg-0">
                                                     {destinationDevice?.name}
+                                                    <div className="mt-2">
+                                                        <OnlineStatusTag
+                                                            isOnline={
+                                                                destinationDevice?.online ||
+                                                                false
+                                                            }
+                                                        />
+                                                    </div>
                                                 </div>
                                                 <div className="d-block d-lg-none col-4 py-3 bg-black bg-opacity-5 text-black text-opacity-45">
                                                     目標 Pin


### PR DESCRIPTION
# 修改內容

- feat: 拉出共用的 online-status-tag
- feat: 在 triggers page 的來源/目標裝置顯示 online-status
- refactor: 將 devices/device page 的 online-status 用共用元件替代

# 修改專案

- Dashboard F2E

# 測試網址和方式

- 確認 devices/device/triggers page 的 online-status 正常顯示

![截圖 2022-05-15 下午9 59 05](https://user-images.githubusercontent.com/56446970/168476651-b3c83e79-f92e-40f4-a542-d11c188fc89d.png)

# Reviewers

@miterfrants  @vickychou99 
