### PR TITLE
refactor: 修正 page-title component 在比較小尺寸上的斷行

### DIFF
--- a/dashboard/src/app.tsx
+++ b/dashboard/src/app.tsx
@@ -1,6 +1,6 @@
 import './app.scss';
 import { useEffect } from 'react';
-import { Outlet } from 'react-router-dom';
+import { Outlet, useLocation } from 'react-router-dom';
 import { useQuery } from './hooks/query.hook';
 import { useGetTriggerOperatorsApi } from '@/hooks/apis/universal.hook';
 import { useGetMicrocontrollersApi } from '@/hooks/apis/universal.hook';
@@ -10,11 +10,15 @@ import Header from './components/header/header';
 import Footer from './components/footer/footer';
 import Dialog from './components/dialog/dialog';
 import Toaster from './components/toaster/toaster';
+import { useAppDispatch } from './hooks/redux.hook';
+import { menuActions } from './redux/reducers/menu.reducer';
 
 const isDev = import.meta.env.VITE_ENV === 'dev';
 
 const App = () => {
     const query = useQuery();
+    const location = useLocation();
+    const dispatch = useAppDispatch();
     const dashboardTokenFromQueryString =
         query.get(COOKIE_KEY.DASHBOARD_TOKEN) || '';
 
@@ -27,7 +31,7 @@ const App = () => {
 
     const token = CookieHelpers.GetCookie({ name: COOKIE_KEY.DASHBOARD_TOKEN });
     if (!token) {
-        location.href = import.meta.env.VITE_WEBSITE_URL;
+        window.location.href = import.meta.env.VITE_WEBSITE_URL;
     }
 
     const { getTriggerOperatorsApi } = useGetTriggerOperatorsApi();
@@ -39,6 +43,12 @@ const App = () => {
     useEffect(() => {
         getMicrocontrollersApi();
     }, []);
+
+    useEffect(() => {
+        if (document.body.clientWidth <= 767) {
+            dispatch(menuActions.close());
+        }
+    }, [location]);
 
     return token ? (
         <div className="dashboard" data-testid="Dashboard">

--- a/dashboard/src/app.tsx
+++ b/dashboard/src/app.tsx
@@ -1,6 +1,6 @@
 import './app.scss';
 import { useEffect } from 'react';
-import { Outlet, useLocation } from 'react-router-dom';
+import { Outlet } from 'react-router-dom';
 import { useQuery } from './hooks/query.hook';
 import { useGetTriggerOperatorsApi } from '@/hooks/apis/universal.hook';
 import { useGetMicrocontrollersApi } from '@/hooks/apis/universal.hook';
@@ -10,15 +10,11 @@ import Header from './components/header/header';
 import Footer from './components/footer/footer';
 import Dialog from './components/dialog/dialog';
 import Toaster from './components/toaster/toaster';
-import { useAppDispatch } from './hooks/redux.hook';
-import { menuActions } from './redux/reducers/menu.reducer';
 
 const isDev = import.meta.env.VITE_ENV === 'dev';
 
 const App = () => {
     const query = useQuery();
-    const location = useLocation();
-    const dispatch = useAppDispatch();
     const dashboardTokenFromQueryString =
         query.get(COOKIE_KEY.DASHBOARD_TOKEN) || '';
 
@@ -43,12 +39,6 @@ const App = () => {
     useEffect(() => {
         getMicrocontrollersApi();
     }, []);
-
-    useEffect(() => {
-        if (document.body.clientWidth <= 767) {
-            dispatch(menuActions.close());
-        }
-    }, [location]);
 
     return token ? (
         <div className="dashboard" data-testid="Dashboard">

--- a/dashboard/src/components/footer/footer.tsx
+++ b/dashboard/src/components/footer/footer.tsx
@@ -5,20 +5,6 @@ const Footer = () => (
         className="footer d-flex justify-content-between p-5 fs-5"
         data-testid="Footer"
     >
-        <div className="flex-fill">
-            <Link
-                to="/dashboard/"
-                className="text-decoration-none text-black text-opacity-65"
-            >
-                關於我們
-            </Link>
-            <Link
-                to="/dashboard/"
-                className="text-decoration-none text-black text-opacity-65 ps-5"
-            >
-                隱私權政策
-            </Link>
-        </div>
         <div className="flex-fill text-end text-black text-opacity-65">
             Copyright © 2021 itemhub Inc. All rights reserved.
         </div>

--- a/dashboard/src/components/header/header.tsx
+++ b/dashboard/src/components/header/header.tsx
@@ -1,4 +1,4 @@
-import { Link } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 import { useAppSelector, useAppDispatch } from '@/hooks/redux.hook';
 import { menuActions, selectMenu } from '@/redux/reducers/menu.reducer';
 import triggerIcon from '@/assets/images/trigger.svg';
@@ -13,6 +13,7 @@ const Header = () => {
     const isOpen = useAppSelector(selectMenu).menu.isOpen;
     const dispatch = useAppDispatch();
     const [menuBlockClassName, setMenuBlockClassName] = useState('d-none');
+    const location = useLocation();
 
     useEffect(() => {
         if (isOpen) {
@@ -23,6 +24,12 @@ const Header = () => {
             }, 500);
         }
     }, [isOpen]);
+
+    useEffect(() => {
+        if (document.body.clientWidth <= 767) {
+            dispatch(menuActions.close());
+        }
+    }, [location]);
 
     const closeMenu = () => {
         dispatch(menuActions.close());

--- a/dashboard/src/components/page-title/page-title.tsx
+++ b/dashboard/src/components/page-title/page-title.tsx
@@ -53,7 +53,7 @@ const PageTitle = (props: {
                         <h3
                             role={titleClickCallback ? 'button' : ''}
                             onClick={titleClickCallback}
-                            className="text-break text-black text-opacity-85 mb-0"
+                            className="text-break text-black text-opacity-85 mb-3 mb-sm-0"
                         >
                             <img
                                 className={`icon me-3 ${
@@ -64,10 +64,10 @@ const PageTitle = (props: {
                             {title}
                         </h3>
 
-                        <div className="d-flex">
+                        <div className="d-flex flex-wrap">
                             <button
                                 onClick={thirdlyButtonCallback}
-                                className={`${
+                                className={`mb-3 mb-sm-0 ${
                                     thirdlyButtonVisible ? ' me-3' : 'd-none'
                                 } ${
                                     thirdlyButtonClassName ||
@@ -82,7 +82,7 @@ const PageTitle = (props: {
                             </button>
                             <button
                                 onClick={secondaryButtonCallback}
-                                className={`${
+                                className={`mb-3 mb-sm-0 ${
                                     secondaryButtonVisible ? ' me-3' : 'd-none'
                                 } ${
                                     secondaryButtonClassName ||
@@ -97,7 +97,7 @@ const PageTitle = (props: {
                             </button>
                             <button
                                 onClick={primaryButtonCallback}
-                                className={`${
+                                className={`mb-3 mb-sm-0 ${
                                     primaryButtonVisible ? '' : 'd-none'
                                 } ${
                                     primaryButtonClassName || 'btn btn-primary'

--- a/dashboard/src/pages/dashboard/dashboard.scss
+++ b/dashboard/src/pages/dashboard/dashboard.scss
@@ -1,5 +1,5 @@
 .dashboard {
-    min-height: 100vh;
+    min-height: -webkit-fill-available;
     .content {
         @include media-breakpoint-down(md) {
             padding-top: $mobile-header-h;

--- a/dashboard/src/pages/dashboard/dashboard.scss
+++ b/dashboard/src/pages/dashboard/dashboard.scss
@@ -1,4 +1,5 @@
 .dashboard {
+    min-height: 100vh;
     .content {
         @include media-breakpoint-down(md) {
             padding-top: $mobile-header-h;

--- a/dashboard/src/redux/reducers/menu.reducer.ts
+++ b/dashboard/src/redux/reducers/menu.reducer.ts
@@ -11,7 +11,6 @@ export const menuSlice = createSlice({
             return { isOpen: true };
         },
         close: () => {
-            console.log('testing');
             return { isOpen: false };
         },
     },

--- a/dashboard/src/redux/reducers/menu.reducer.ts
+++ b/dashboard/src/redux/reducers/menu.reducer.ts
@@ -11,6 +11,7 @@ export const menuSlice = createSlice({
             return { isOpen: true };
         },
         close: () => {
+            console.log('testing');
             return { isOpen: false };
         },
     },


### PR DESCRIPTION


# 修改內容

- 修正 page-title component 在比較小尺寸上的斷行
- UX 小尺寸的螢幕再切換連結的時候會把 menu 收起來

# 修改專案

- Dashboard F2E


# 測試網址和方式

- 把畫面縮小到 <=767 展開選單, 切換連結看一下是否選單會自動縮起來
- 切到 http://localhost:3000/dashboard/oauth-clients 看一下按鈕是否有放在不同列顯示 e.g
<img width="422" alt="截圖 2022-05-16 上午1 09 46" src="https://user-images.githubusercontent.com/2028693/168485222-fbbda65f-801a-411a-8d25-0da8f1f193a6.png">


# Reviewers
@LiangYingC @vickychou99 
