### PR TITLE
Feat/implement trigger read mode

### DIFF
--- a/dashboard/src/components/page-title/page-title.tsx
+++ b/dashboard/src/components/page-title/page-title.tsx
@@ -1,11 +1,34 @@
-import { useAppDispatch, useAppSelector } from '@/hooks/redux.hook';
-import { menuActions, selectMenu } from '@/redux/reducers/menu.reducer';
+import Breadcrumbs from '@/components/breadcrumbs/breadcrumbs';
 import refreshIcon from '/src/assets/images/icon-refresh.svg';
 import plusIcon from '/src/assets/images/icon-plus.svg';
 import leftArrowIcon from '/src/assets/images/left-arrow.svg';
 
-const PageTitle = (props: {
+const PageTitle = ({
+    title,
+    breadcrumbs,
+    titleClickCallback,
+    titleBackIconVisible,
+    primaryButtonVisible,
+    secondaryButtonVisible,
+    thirdlyButtonVisible,
+    primaryButtonCallback,
+    primaryButtonWording,
+    secondaryButtonCallback,
+    secondaryButtonWording,
+    thirdlyButtonCallback,
+    thirdlyButtonWording,
+    primaryButtonIcon,
+    primaryButtonClassName,
+    secondaryButtonClassName,
+    secondaryButtonIcon,
+    thirdlyButtonClassName,
+    thirdlyButtonIcon,
+}: {
     title: string;
+    breadcrumbs?: {
+        label: string;
+        pathName: string;
+    }[];
     titleClickCallback?: () => void;
     titleBackIconVisible?: boolean;
     primaryButtonVisible?: boolean;
@@ -24,31 +47,11 @@ const PageTitle = (props: {
     thirdlyButtonIcon?: string;
     thirdlyButtonClassName?: string;
 }) => {
-    const {
-        title,
-        titleClickCallback,
-        titleBackIconVisible,
-        primaryButtonVisible,
-        secondaryButtonVisible,
-        thirdlyButtonVisible,
-        primaryButtonCallback,
-        primaryButtonWording,
-        secondaryButtonCallback,
-        secondaryButtonWording,
-        thirdlyButtonCallback,
-        thirdlyButtonWording,
-        primaryButtonIcon,
-        primaryButtonClassName,
-        secondaryButtonClassName,
-        secondaryButtonIcon,
-        thirdlyButtonClassName,
-        thirdlyButtonIcon,
-    } = props;
-
     return (
         <div className="page-title" data-testid="page-title">
             <div className="w-100 px-45 pt-45 mb-45">
                 <div className="flex-fill">
+                    {breadcrumbs && <Breadcrumbs breadcrumbs={breadcrumbs} />}
                     <div className="d-flex align-items-start justify-content-between flex-wrap">
                         <h3
                             role={titleClickCallback ? 'button' : ''}

--- a/dashboard/src/components/page-title/page-title.tsx
+++ b/dashboard/src/components/page-title/page-title.tsx
@@ -56,7 +56,7 @@ const PageTitle = ({
                         <h3
                             role={titleClickCallback ? 'button' : ''}
                             onClick={titleClickCallback}
-                            className="text-break text-black text-opacity-85 mb-3 mb-sm-0"
+                            className="d-flex align-items-center text-break text-black text-opacity-85 mb-3 mb-sm-0"
                         >
                             <img
                                 className={`icon me-3 ${

--- a/dashboard/src/hooks/apis/oauth-clients.hook.ts
+++ b/dashboard/src/hooks/apis/oauth-clients.hook.ts
@@ -191,10 +191,13 @@ export const useDeleteOauthClients = (ids: number[]) => {
     });
 };
 
-export const useCreateOauthClients = (
-    clientId: string,
-    deviceId: number | null
-) => {
+export const useCreateOauthClients = ({
+    clientId,
+    deviceId,
+}: {
+    clientId: string;
+    deviceId: number | null;
+}) => {
     const dispatch = useAppDispatch();
     const dispatchRefresh = useCallback(
         (response: OauthClient) => {

--- a/dashboard/src/index.tsx
+++ b/dashboard/src/index.tsx
@@ -36,6 +36,10 @@ ReactDOM.render(
                     path="dashboard/devices/create"
                     element={<DevicePinData />}
                 />
+                <Route
+                    path="dashboard/devices/edit/:id"
+                    element={<DevicePinData />}
+                />
                 <Route path="dashboard/triggers" element={<Triggers />} />
                 <Route path="dashboard/triggers/create" element={<Trigger />} />
                 <Route

--- a/dashboard/src/pages/device-pin-data/device-pin-data.tsx
+++ b/dashboard/src/pages/device-pin-data/device-pin-data.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams, useLocation } from 'react-router-dom';
 import {
     useCreateDeviceApi,
     useGetDeviceApi,
@@ -292,10 +292,21 @@ const DevicePinData = () => {
         }
     }, [createDevicePinResponse]);
 
+    const breadcrumbs = [
+        {
+            label: '裝置列表',
+            pathName: '/dashboard/devices',
+        },
+        {
+            label: isCreateMode ? '新增' : '編輯',
+            pathName: useLocation().pathname,
+        },
+    ];
+
     return (
-        // UI 結構等設計稿後再重構調整
         <div className="device-pin-data" data-testid="device-pin-data">
             <PageTitle
+                breadcrumbs={breadcrumbs}
                 titleClickCallback={back}
                 titleBackIconVisible
                 title={isCreateMode ? '新增裝置' : '編輯裝置'}

--- a/dashboard/src/pages/device/device.tsx
+++ b/dashboard/src/pages/device/device.tsx
@@ -1,6 +1,6 @@
 import moment from 'moment';
 import { useRef, useState, useEffect } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams, useLocation } from 'react-router-dom';
 import {
     useDeleteDevicesApi,
     useGetDeviceApi,
@@ -211,13 +211,24 @@ const Device = () => {
         );
     };
 
+    const breadcrumbs = [
+        {
+            label: '裝置列表',
+            pathName: '/dashboard/devices',
+        },
+        {
+            label: '裝置詳細頁',
+            pathName: useLocation().pathname,
+        },
+    ];
+
     return (
-        // UI 結構等設計稿後再重構調整
         <div className="device" data-testid="device">
             <PageTitle
+                title={`${deviceName}詳細內容`}
+                breadcrumbs={breadcrumbs}
                 titleClickCallback={backToList}
                 titleBackIconVisible
-                title={`${deviceName}詳細內容`}
                 primaryButtonVisible
                 primaryButtonWording="編輯"
                 primaryButtonCallback={jumpToEditPage}

--- a/dashboard/src/pages/device/device.tsx
+++ b/dashboard/src/pages/device/device.tsx
@@ -69,7 +69,7 @@ const Device = () => {
     };
 
     const jumpToEditPage = () => {
-        navigate('edit');
+        navigate(`/dashboard/devices/edit/${Number(id)}`);
     };
 
     const bundleFirmware = () => {

--- a/dashboard/src/pages/oauth-client/oauth-client.tsx
+++ b/dashboard/src/pages/oauth-client/oauth-client.tsx
@@ -69,7 +69,7 @@ const OauthClient = () => {
         fetchApi: createApi,
         isLoading: isCreating,
         data: createOAuthClientResponse,
-    } = useCreateOauthClients(clientId);
+    } = useCreateOauthClients({ clientId, deviceId: null });
 
     useEffect(() => {
         if (oauthClient || isDeleting || isCreateMode) {

--- a/dashboard/src/pages/oauth-client/oauth-client.tsx
+++ b/dashboard/src/pages/oauth-client/oauth-client.tsx
@@ -133,12 +133,24 @@ const OauthClient = () => {
         );
     };
 
+    const breadcrumbs = [
+        {
+            label: 'oAuthClient 列表',
+            pathName: '/dashboard/oauth-clients',
+        },
+        {
+            label: isCreateMode ? '新增' : '編輯',
+            pathName: useLocation().pathname,
+        },
+    ];
+
     return (
         <div className="oauth-client" data-testid="oauth-client">
             <PageTitle
+                title="oAuthClient 詳細內容"
+                breadcrumbs={breadcrumbs}
                 titleClickCallback={backToList}
                 titleBackIconVisible
-                title="oAuthClient 詳細內容"
                 primaryButtonVisible={!isCreateMode}
                 primaryButtonWording="刪除"
                 primaryButtonCallback={deleteClient}

--- a/dashboard/src/pages/trigger/trigger-form/trigger-form.tsx
+++ b/dashboard/src/pages/trigger/trigger-form/trigger-form.tsx
@@ -107,7 +107,7 @@ const TriggerForm = ({
     ];
 
     return (
-        <div className="trigger-form-wrapper px-3 px-lg-0 mx-auto mt-4 mt-lg-5">
+        <div className="trigger-form-wrapper px-3 px-lg-0 mx-auto mt-4 mt-lg-4">
             <Breadcrumbs breadcrumbs={breadcrumbs} />
             <h3
                 className="title d-flex align-item-center mb-3 mb-lg-4"

--- a/dashboard/src/pages/trigger/trigger.tsx
+++ b/dashboard/src/pages/trigger/trigger.tsx
@@ -5,23 +5,27 @@ import {
     useGetTriggerApi,
     useDeleteTriggersApi,
 } from '@/hooks/apis/triggers.hook';
+import { Link } from 'react-router-dom';
 import { RESPONSE_STATUS } from '@/constants/api';
 import { dialogActions, DialogTypeEnum } from '@/redux/reducers/dialog.reducer';
 import {
     toasterActions,
     ToasterTypeEnum,
 } from '@/redux/reducers/toaster.reducer';
+import { selectUniversal } from '@/redux/reducers/universal.reducer';
 import { selectTriggers } from '@/redux/reducers/triggers.reducer';
 import { TriggerItem } from '@/types/triggers.type';
 import TriggerForm from './trigger-form/trigger-form';
 import PageTitle from '@/components/page-title/page-title';
 import Spinner from '@/components/spinner/spinner';
+import OnlineStatusTag from '@/components/online-status-tag/online-status-tag';
 import trashIcon from '@/assets/images/trash.svg';
 
 const Trigger = () => {
     const location = useLocation();
     const navigate = useNavigate();
     const dispatch = useAppDispatch();
+    const { triggerOperators } = useAppSelector(selectUniversal);
 
     const { id: idFromUrl } = useParams();
     const triggerId = idFromUrl ? parseInt(idFromUrl) : null;
@@ -93,27 +97,95 @@ const Trigger = () => {
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [deleteTriggersResponse, dispatch]);
 
+    const isLoading = isGettingTrigger || (trigger === null && !isCreateMode);
+    const isReadMode = !isCreateMode && !isEditMode && trigger !== null;
+
     return (
         <div className="trigger" data-testid="trigger">
-            {isGettingTrigger || (trigger === null && !isCreateMode) ? (
+            {isLoading ? (
                 <div className="w-100 d-flex justify-content-center mt-5">
                     <Spinner />
                 </div>
-            ) : isCreateMode || isEditMode ? (
-                <TriggerForm trigger={trigger} isCreateMode={isCreateMode} />
+            ) : isReadMode ? (
+                <>
+                    <PageTitle
+                        titleClickCallback={jumpToListPage}
+                        titleBackIconVisible
+                        title={triggerName}
+                        primaryButtonVisible
+                        primaryButtonWording="編輯"
+                        primaryButtonCallback={jumpToEditPage}
+                        secondaryButtonVisible
+                        secondaryButtonIcon={trashIcon}
+                        secondaryButtonWording="刪除"
+                        secondaryButtonCallback={confirmToDeleteTrigger}
+                    />
+                    <div className="card">
+                        <div className="row m-0 border border-white">
+                            <div className="col-4 col-md-2 col-lg-2 py-2 bg-black bg-opacity-5 text-black text-opacity-45">
+                                事件
+                            </div>
+                            <div className="col-8 col-md-10 col-lg-4 py-2">
+                                <div className="d-flex">
+                                    <div className="me-2">
+                                        <Link
+                                            to={`/dashboard/devices/${trigger.sourceDeviceId}`}
+                                        >
+                                            {trigger.sourceDevice?.name}
+                                        </Link>
+                                    </div>
+                                    <OnlineStatusTag
+                                        isOnline={
+                                            trigger.sourceDevice?.online ||
+                                            false
+                                        }
+                                    />
+                                </div>
+                                <div>Pin: {trigger.sourcePin}</div>
+                            </div>
+                            <div className="col-4 col-md-2 col-lg-2 py-2 bg-black bg-opacity-5 text-black text-opacity-45">
+                                條件
+                            </div>
+                            <div className="col-8 col-md-10 col-lg-4 py-2">
+                                {triggerOperators[trigger.operator]?.label}{' '}
+                                {trigger.sourceThreshold}
+                            </div>
+                        </div>
+                        <div className="row m-0 border border-white">
+                            <div className="col-4 col-md-2 col-lg-2 py-2 bg-black bg-opacity-5 text-black text-opacity-45">
+                                目標
+                            </div>
+                            <div className="col-8 col-md-10 col-lg-4 py-2">
+                                <div className="d-flex">
+                                    <div className="me-2">
+                                        <Link
+                                            to={`/dashboard/devices/${trigger.destinationDeviceId}`}
+                                        >
+                                            {trigger.destinationDevice?.name}
+                                        </Link>
+                                    </div>
+                                    <OnlineStatusTag
+                                        isOnline={
+                                            trigger.destinationDevice?.online ||
+                                            false
+                                        }
+                                    />
+                                </div>
+                                <div>Pin: {trigger.destinationPin}</div>
+                            </div>
+                            <div className="col-4 col-md-2 col-lg-2 py-2 bg-black bg-opacity-5 text-black text-opacity-45">
+                                目標狀態
+                            </div>
+                            <div className="col-8 col-md-10 col-lg-4 py-2">
+                                {trigger.destinationDeviceTargetState === 1
+                                    ? '開'
+                                    : '關'}
+                            </div>
+                        </div>
+                    </div>
+                </>
             ) : (
-                <PageTitle
-                    titleClickCallback={jumpToListPage}
-                    titleBackIconVisible
-                    title={triggerName}
-                    primaryButtonVisible
-                    primaryButtonWording="編輯"
-                    primaryButtonCallback={jumpToEditPage}
-                    secondaryButtonVisible
-                    secondaryButtonIcon={trashIcon}
-                    secondaryButtonWording="刪除"
-                    secondaryButtonCallback={confirmToDeleteTrigger}
-                />
+                <TriggerForm trigger={trigger} isCreateMode={isCreateMode} />
             )}
         </div>
     );

--- a/dashboard/src/pages/trigger/trigger.tsx
+++ b/dashboard/src/pages/trigger/trigger.tsx
@@ -99,6 +99,16 @@ const Trigger = () => {
 
     const isLoading = isGettingTrigger || (trigger === null && !isCreateMode);
     const isReadMode = !isCreateMode && !isEditMode && trigger !== null;
+    const breadcrumbsForReadMode = [
+        {
+            label: '觸發列表',
+            pathName: '/dashboard/triggers',
+        },
+        {
+            label: '觸發詳細頁',
+            pathName: location.pathname,
+        },
+    ];
 
     return (
         <div className="trigger" data-testid="trigger">
@@ -109,9 +119,10 @@ const Trigger = () => {
             ) : isReadMode ? (
                 <>
                     <PageTitle
+                        title={triggerName}
+                        breadcrumbs={breadcrumbsForReadMode}
                         titleClickCallback={jumpToListPage}
                         titleBackIconVisible
-                        title={triggerName}
                         primaryButtonVisible
                         primaryButtonWording="編輯"
                         primaryButtonCallback={jumpToEditPage}

--- a/dashboard/src/pages/trigger/trigger.tsx
+++ b/dashboard/src/pages/trigger/trigger.tsx
@@ -1,15 +1,27 @@
 import { useEffect } from 'react';
-import { useParams, useLocation } from 'react-router-dom';
-import { useAppSelector } from '@/hooks/redux.hook';
-import { useGetTriggerApi } from '@/hooks/apis/triggers.hook';
+import { useParams, useLocation, useNavigate } from 'react-router-dom';
+import { useAppSelector, useAppDispatch } from '@/hooks/redux.hook';
+import {
+    useGetTriggerApi,
+    useDeleteTriggersApi,
+} from '@/hooks/apis/triggers.hook';
+import { RESPONSE_STATUS } from '@/constants/api';
+import { dialogActions, DialogTypeEnum } from '@/redux/reducers/dialog.reducer';
+import {
+    toasterActions,
+    ToasterTypeEnum,
+} from '@/redux/reducers/toaster.reducer';
 import { selectTriggers } from '@/redux/reducers/triggers.reducer';
 import { TriggerItem } from '@/types/triggers.type';
 import TriggerForm from './trigger-form/trigger-form';
 import PageTitle from '@/components/page-title/page-title';
 import Spinner from '@/components/spinner/spinner';
+import trashIcon from '@/assets/images/trash.svg';
 
 const Trigger = () => {
     const location = useLocation();
+    const navigate = useNavigate();
+    const dispatch = useAppDispatch();
 
     const { id: idFromUrl } = useParams();
     const triggerId = idFromUrl ? parseInt(idFromUrl) : null;
@@ -25,15 +37,61 @@ const Trigger = () => {
         triggers?.filter((trigger) => trigger.id === triggerId)[0] ||
         createTriggerLocationState?.trigger ||
         null;
+    const triggerName = trigger?.name || '--';
 
     const { isGettingTrigger, getTriggerApi } = useGetTriggerApi(
         triggerId || 0
     );
+
+    const { isDeletingTriggers, deleteTriggersApi, deleteTriggersResponse } =
+        useDeleteTriggersApi([triggerId || 0]);
+
+    const jumpToEditPage = () => {
+        navigate(`/dashboard/triggers/edit/${triggerId}`);
+    };
+
+    const jumpToListPage = () => {
+        navigate('/dashboard/triggers');
+    };
+
+    const confirmToDeleteTrigger = () => {
+        if (!isDeletingTriggers) {
+            dispatch(
+                dialogActions.open({
+                    message: '刪除後將無法復原, 請輸入 DELETE 完成刪除',
+                    title: `確認刪除 "${triggerName}" ?`,
+                    type: DialogTypeEnum.PROMPT,
+                    checkedMessage: 'DELETE',
+                    callback: deleteTriggersApi,
+                    promptInvalidMessage: '輸入錯誤，請再次嘗試',
+                })
+            );
+        }
+    };
+
     useEffect(() => {
         if (trigger === null && triggerId) {
             getTriggerApi();
         }
     }, [trigger, triggerId, getTriggerApi]);
+
+    useEffect(() => {
+        if (
+            triggerId &&
+            deleteTriggersResponse &&
+            deleteTriggersResponse.status === RESPONSE_STATUS.OK
+        ) {
+            dispatch(
+                toasterActions.pushOne({
+                    message: `${triggerName} 已經成功刪除`,
+                    duration: 5,
+                    type: ToasterTypeEnum.INFO,
+                })
+            );
+            jumpToListPage();
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [deleteTriggersResponse, dispatch]);
 
     return (
         <div className="trigger" data-testid="trigger">
@@ -44,8 +102,18 @@ const Trigger = () => {
             ) : isCreateMode || isEditMode ? (
                 <TriggerForm trigger={trigger} isCreateMode={isCreateMode} />
             ) : (
-                // TODO: implement read mode
-                <PageTitle title={trigger?.name || '尚無觸發名稱'} />
+                <PageTitle
+                    titleClickCallback={jumpToListPage}
+                    titleBackIconVisible
+                    title={triggerName}
+                    primaryButtonVisible
+                    primaryButtonWording="編輯"
+                    primaryButtonCallback={jumpToEditPage}
+                    secondaryButtonVisible
+                    secondaryButtonIcon={trashIcon}
+                    secondaryButtonWording="刪除"
+                    secondaryButtonCallback={confirmToDeleteTrigger}
+                />
             )}
         </div>
     );

--- a/dashboard/src/pages/triggers/triggers.tsx
+++ b/dashboard/src/pages/triggers/triggers.tsx
@@ -441,17 +441,26 @@ const Triggers = () => {
                                                 <div className="d-block d-lg-none col-4 py-3 bg-black bg-opacity-5 text-black text-opacity-45">
                                                     操作
                                                 </div>
-                                                <div className="col-8 col-lg-2 py-3 py-lg-0 d-flex justify-content-start flex-wrap">
-                                                    <Link
+                                                <div
+                                                    className="col-8 col-lg-2 py-3 py-lg-0 d-flex justify-content-start flex-wrap"
+                                                    onClick={(e) => {
+                                                        e.stopPropagation();
+                                                        navigate(
+                                                            `/dashboard/triggers/edit/${id}`
+                                                        );
+                                                    }}
+                                                    data-tip="編輯"
+                                                >
+                                                    <span
                                                         className="me-3 mb-3 align-items-start d-flex"
-                                                        to={`/dashboard/triggers/edit/${id}`}
                                                         data-tip="編輯"
                                                     >
                                                         <img src={pencilIcon} />
-                                                    </Link>
+                                                    </span>
                                                     <button
                                                         className="btn mb-3 align-items-start d-flex p-0 bg-transparent shadow-none"
-                                                        onClick={() => {
+                                                        onClick={(e) => {
+                                                            e.stopPropagation();
                                                             confirmToDeleteOneTrigger(
                                                                 { id, name }
                                                             );

--- a/dashboard/src/pages/triggers/triggers.tsx
+++ b/dashboard/src/pages/triggers/triggers.tsx
@@ -342,13 +342,21 @@ const Triggers = () => {
                                                 role="button"
                                                 className="row list border-bottom border-black border-opacity-10 p-0 m-0 py-lg-4 px-lg-3"
                                                 onClick={() => {
-                                                    updateSelectedIds(id);
+                                                    navigate(
+                                                        `/dashboard/triggers/${id}`
+                                                    );
                                                 }}
                                             >
                                                 <div className="d-block d-lg-none py-3 col-4 bg-black bg-opacity-5 text-black text-opacity-45">
                                                     觸發名稱
                                                 </div>
-                                                <div className="col-8 col-lg-3 py-3 py-lg-0 d-flex flex-column flex-lg-row align-items-start">
+                                                <div
+                                                    className="col-8 col-lg-3 py-3 py-lg-0 d-flex flex-column flex-lg-row align-items-start"
+                                                    onClick={(e) => {
+                                                        e.stopPropagation();
+                                                        updateSelectedIds(id);
+                                                    }}
+                                                >
                                                     <input
                                                         className="me-3 mt-2"
                                                         type="checkbox"


### PR DESCRIPTION
# 修改內容

- 實作 trigger read mode，有跟 peter 新調整的 trigger list page align 資訊呈現，所以與設計稿略有不同
- 幫 device/oauthClien/trigger 等頁面，補上麵包屑

![截圖 2022-05-16 下午10 39 39](https://user-images.githubusercontent.com/56446970/168618725-7d31f671-9a27-455c-a3da-7e55abd5a63e.png)

有需要的話可以 by commits 看。

https://www.figma.com/file/eqxlwbzWPRrdMDCede74yX/itemhub

# 修改專案

- Dashboard F2E

# 測試網址和方式

- http://localhost:3000/dashboard/triggers/${trigger-id} 檢查資訊是否正常呈現

# Reviewers

@miterfrants  @vickychou99 
