### PR TITLE
fix: make sure will setData/setHttpStatus before callbackfunc executed

### DIFF
--- a/dashboard/src/hooks/apis/fetch.hook.ts
+++ b/dashboard/src/hooks/apis/fetch.hook.ts
@@ -39,11 +39,11 @@ export const useFetchApi = <T>({
             const data = result.data;
 
             if (!controller.signal.aborted) {
+                setHttpStatus(result.httpStatus);
+                setData(data);
                 if (callbackFunc) {
                     callbackFunc(data);
                 }
-                setHttpStatus(result.httpStatus);
-                setData(data);
             }
         } catch (error: any) {
             const errorData: FetchErrorResultData = error?.data || {

--- a/dashboard/src/redux/reducers/triggers.reducer.ts
+++ b/dashboard/src/redux/reducers/triggers.reducer.ts
@@ -36,15 +36,16 @@ export const triggersSlice = createSlice({
                 };
             }
 
-            const targetIndex = triggers.findIndex(
+            const newTriggers = [...triggers];
+            const targetIndex = newTriggers.findIndex(
                 (trigger) => trigger.id === newTrigger.id
             );
-            triggers[targetIndex] = {
+            newTriggers[targetIndex] = {
                 ...newTrigger,
             };
             return {
                 ...state,
-                triggers,
+                triggers: newTriggers,
             };
         },
         addTrigger: (state, action: PayloadAction<TriggerItem>) => {
@@ -57,7 +58,7 @@ export const triggersSlice = createSlice({
 
             return {
                 ...state,
-                oauthClients: [newTrigger, ...triggers],
+                triggers: [newTrigger, ...triggers],
             };
         },
         updateTrigger: (state, action: PayloadAction<Partial<TriggerItem>>) => {
@@ -68,17 +69,18 @@ export const triggersSlice = createSlice({
                 throw new Error('Can not updateTrigger when triggers is null.');
             }
 
-            const targetIndex = triggers.findIndex(
+            const newTriggers = [...triggers];
+            const targetIndex = newTriggers.findIndex(
                 (trigger) => trigger.id === newTrigger.id
             );
-            triggers[targetIndex] = {
+            newTriggers[targetIndex] = {
                 ...triggers[targetIndex],
                 ...newTrigger,
             };
 
             return {
                 ...state,
-                triggers,
+                triggers: newTriggers,
             };
         },
         deleteTriggers: (state, action: PayloadAction<number[]>) => {


### PR DESCRIPTION
# 修改內容

目前看來 `useFetchApi` 中，某些情況下，callback 執行完畢後，就會 return，不會繼續執行到  `setData/setHttpsetHttpStatus`，順序有點不對，應該是要先執行 `setData/setHttpsetHttpStatus` 才執行 callback 才合理。

- 確保 `setData/setHttpsetHttpStatus` 一定會執行到，不會因為 callback 的任何作用而被阻擋

# 修改專案

- Dashboard F2E

# 測試網址和方式

```
  const { isUpdatingTrigger, updateTriggerApi, updateTriggerResponse } =
        useUpdateTriggerApi({
            trigerId: trigger?.id || 0,
            updatedData: {
                ...editedTriggerData,
                sourceThreshold: Number(editedTriggerData.sourceThreshold),
            },
        });
```

update trigger 成功後，`updateTriggerResponse` 會回傳 {status:ok}

# Reviewers

@miterfrants  @vickychou99 
