### PR TITLE
Refactor/let trigger operation constants sign from api

### DIFF
--- a/api/Controllers/UniversalController.cs
+++ b/api/Controllers/UniversalController.cs
@@ -1,7 +1,6 @@
 using Microsoft.AspNetCore.Mvc;
 using Homo.AuthApi;
 using Homo.Api;
-using System;
 using System.Collections.Generic;
 using System.Linq;
 

--- a/api/Controllers/UniversalController.cs
+++ b/api/Controllers/UniversalController.cs
@@ -1,8 +1,10 @@
 using Microsoft.AspNetCore.Mvc;
 using Homo.AuthApi;
+using Homo.Api;
+using System;
 using System.Collections.Generic;
 using System.Linq;
-using Homo.Api;
+
 
 namespace Homo.IotApi
 {
@@ -55,7 +57,75 @@ namespace Homo.IotApi
         [Route("trigger-operators")]
         public ActionResult<dynamic> getTriggerOperators()
         {
-            return ConvertHelper.EnumToList(typeof(TRIGGER_OPERATOR));
+            List<ConvertHelper.EnumList> triggerOperators= ConvertHelper.EnumToList(typeof(TRIGGER_OPERATOR));
+            List<ConvertHelper.EnumListWithSymbol> triggerWithSignOperators = new List<ConvertHelper.EnumListWithSymbol>();
+            triggerOperators.ForEach(triggerOperator => 
+                {
+                    if (triggerOperator.Key == TRIGGER_OPERATOR.B.ToString()) 
+                    {
+                        triggerWithSignOperators.Add(new ConvertHelper.EnumListWithSymbol()
+                        {
+                            Key = triggerOperator.Key,
+                            Label = triggerOperator.Label,
+                            Value = triggerOperator.Value,
+                            Symbol = ">"
+                        });
+                        return;
+                    } 
+                    if (triggerOperator.Key == TRIGGER_OPERATOR.BE.ToString()) 
+                    {
+                        triggerWithSignOperators.Add(new ConvertHelper.EnumListWithSymbol()
+                        {
+                            Key = triggerOperator.Key,
+                            Label = triggerOperator.Label,
+                            Value = triggerOperator.Value,
+                            Symbol = ">="
+                        });
+                        return;
+                    }
+                    if (triggerOperator.Key == TRIGGER_OPERATOR.L.ToString())
+                    {
+                        triggerWithSignOperators.Add(new ConvertHelper.EnumListWithSymbol()
+                        {
+                            Key = triggerOperator.Key,
+                            Label = triggerOperator.Label,
+                            Value = triggerOperator.Value,
+                            Symbol = "<"
+                        });
+                        return;
+                    }
+                    if (triggerOperator.Key == TRIGGER_OPERATOR.LE.ToString())
+                    {
+                        triggerWithSignOperators.Add(new ConvertHelper.EnumListWithSymbol()
+                        {
+                            Key = triggerOperator.Key,
+                            Label = triggerOperator.Label,
+                            Value = triggerOperator.Value,
+                            Symbol = "<="
+                        });
+                        return;
+                    }
+                    if (triggerOperator.Key == TRIGGER_OPERATOR.E.ToString())
+                    {
+                        triggerWithSignOperators.Add(new ConvertHelper.EnumListWithSymbol()
+                        {
+                            Key = triggerOperator.Key,
+                            Label = triggerOperator.Label,
+                            Value = triggerOperator.Value,
+                            Symbol = "="
+                        });
+                        return;
+                    }
+                    triggerWithSignOperators.Add(new ConvertHelper.EnumListWithSymbol()
+                    {
+                        Key = triggerOperator.Key,
+                        Label = triggerOperator.Label,
+                        Value = triggerOperator.Value,
+                        Symbol = null
+                    });
+                }
+            );
+            return triggerWithSignOperators;
         }
 
         [HttpGet]

--- a/api/Controllers/UniversalController.cs
+++ b/api/Controllers/UniversalController.cs
@@ -58,74 +58,14 @@ namespace Homo.IotApi
         public ActionResult<dynamic> getTriggerOperators()
         {
             List<ConvertHelper.EnumList> triggerOperators= ConvertHelper.EnumToList(typeof(TRIGGER_OPERATOR));
-            List<ConvertHelper.EnumListWithSymbol> triggerWithSignOperators = new List<ConvertHelper.EnumListWithSymbol>();
-            triggerOperators.ForEach(triggerOperator => 
-                {
-                    if (triggerOperator.Key == TRIGGER_OPERATOR.B.ToString()) 
-                    {
-                        triggerWithSignOperators.Add(new ConvertHelper.EnumListWithSymbol()
-                        {
-                            Key = triggerOperator.Key,
-                            Label = triggerOperator.Label,
-                            Value = triggerOperator.Value,
-                            Symbol = ">"
-                        });
-                        return;
-                    } 
-                    if (triggerOperator.Key == TRIGGER_OPERATOR.BE.ToString()) 
-                    {
-                        triggerWithSignOperators.Add(new ConvertHelper.EnumListWithSymbol()
-                        {
-                            Key = triggerOperator.Key,
-                            Label = triggerOperator.Label,
-                            Value = triggerOperator.Value,
-                            Symbol = ">="
-                        });
-                        return;
-                    }
-                    if (triggerOperator.Key == TRIGGER_OPERATOR.L.ToString())
-                    {
-                        triggerWithSignOperators.Add(new ConvertHelper.EnumListWithSymbol()
-                        {
-                            Key = triggerOperator.Key,
-                            Label = triggerOperator.Label,
-                            Value = triggerOperator.Value,
-                            Symbol = "<"
-                        });
-                        return;
-                    }
-                    if (triggerOperator.Key == TRIGGER_OPERATOR.LE.ToString())
-                    {
-                        triggerWithSignOperators.Add(new ConvertHelper.EnumListWithSymbol()
-                        {
-                            Key = triggerOperator.Key,
-                            Label = triggerOperator.Label,
-                            Value = triggerOperator.Value,
-                            Symbol = "<="
-                        });
-                        return;
-                    }
-                    if (triggerOperator.Key == TRIGGER_OPERATOR.E.ToString())
-                    {
-                        triggerWithSignOperators.Add(new ConvertHelper.EnumListWithSymbol()
-                        {
-                            Key = triggerOperator.Key,
-                            Label = triggerOperator.Label,
-                            Value = triggerOperator.Value,
-                            Symbol = "="
-                        });
-                        return;
-                    }
-                    triggerWithSignOperators.Add(new ConvertHelper.EnumListWithSymbol()
-                    {
-                        Key = triggerOperator.Key,
-                        Label = triggerOperator.Label,
-                        Value = triggerOperator.Value,
-                        Symbol = null
-                    });
-                }
-            );
-            return triggerWithSignOperators;
+            Dictionary<string, string> symbolMapping = new Dictionary<string, string>() { { "B", ">" }, { "BE", ">=" }, { "E", "=" }, { "LE", "<=" }, { "L", "<" } };
+            return triggerOperators.Select(x => new
+            {
+                x.Key,
+                x.Label,
+                x.Value,
+                Symbol = symbolMapping.GetValueOrDefault(x.Key)
+            }).ToList<dynamic>();
         }
 
         [HttpGet]

--- a/api/Homo.AuthApi/Helpers/ConvertHelper.cs
+++ b/api/Homo.AuthApi/Helpers/ConvertHelper.cs
@@ -39,10 +39,5 @@ namespace Homo.AuthApi
             public string Label { get; set; }
             public object Value { get; set; }
         }
-
-        public class EnumListWithSymbol: EnumList
-        {
-            public object Symbol { get; set; }
-        }
     }
 }

--- a/api/Homo.AuthApi/Helpers/ConvertHelper.cs
+++ b/api/Homo.AuthApi/Helpers/ConvertHelper.cs
@@ -39,5 +39,10 @@ namespace Homo.AuthApi
             public string Label { get; set; }
             public object Value { get; set; }
         }
+
+        public class EnumListWithSymbol: EnumList
+        {
+            public object Symbol { get; set; }
+        }
     }
 }

--- a/dashboard/src/redux/reducers/universal.reducer.ts
+++ b/dashboard/src/redux/reducers/universal.reducer.ts
@@ -26,28 +26,10 @@ export const universalSlice = createSlice({
             state,
             action: PayloadAction<TriggerOerator[]>
         ) => {
-            const newTriggerOerators = action.payload.map<TriggerOerator>(
-                (item) => {
-                    return {
-                        ...item,
-                        symbol:
-                            item.key === 'B'
-                                ? '>'
-                                : item.key === 'BE'
-                                ? '>='
-                                : item.key === 'L'
-                                ? '<'
-                                : item.key === 'LE'
-                                ? '<='
-                                : item.key === 'E'
-                                ? '='
-                                : null,
-                    };
-                }
-            );
+            const newTriggerOperators = action.payload;
             return {
                 ...state,
-                triggerOperators: newTriggerOerators,
+                triggerOperators: newTriggerOperators,
             };
         },
         setMicrocontrollers: (

--- a/dashboard/src/types/universal.type.ts
+++ b/dashboard/src/types/universal.type.ts
@@ -2,7 +2,7 @@ export interface TriggerOerator {
     key: 'B' | 'BE' | 'L' | 'LE' | 'E';
     value: 0 | 1 | 2 | 3 | 4;
     label: string;
-    symbol?: '>' | '>=' | '<' | '<=' | '=' | null;
+    symbol: '>' | '>=' | '<' | '<=' | '=' | null;
 }
 
 export interface Microcontroller {


### PR DESCRIPTION
# 修改內容

Ref: https://github.com/miterfrants/itemhub/issues/563

- 在 TriggerOperators API 將 symbol 一起回傳
- Client 端接收到的 TriggerOperators API response 直接包含 symbol，因此拔掉 symbol 邏輯

以上好處是讓  TriggerOperators  constants 統一控管在後端，要改也改後端，前端不需要過度關注

p.s. 覺得 API 端我的 code 蠻醜的，有什麼優化的方式可以在跟我說，或提供給我關鍵字 google 我就會立刻改，謝謝！

# 修改專案

- API
- Dashboard F2E

# 測試網址和方式

- triggers page
- add trigger page
- edit trigger page

以上三個 page 的 trigger operator symbol 與過去一樣顯示 >, >= , <... ，無異常

# Reviewers

@miterfrants  @vickychou99 
