### PR TITLE
fix: 修正如果已經刪除的使用者, 他的 email 還是會被判斷為重複註冊

### DIFF
--- a/api/Homo.AuthApi/Models/EF/DBContext.cs
+++ b/api/Homo.AuthApi/Models/EF/DBContext.cs
@@ -22,7 +22,7 @@ namespace Homo.AuthApi
 
             modelBuilder.Entity<User>(entity =>
             {
-                entity.HasIndex(p => new { p.Email }).IsUnique();
+                entity.HasIndex(p => new { p.Email, p.DeletedAt }).IsUnique();
                 entity.HasIndex(p => new { p.HashPhone });
                 entity.Property(b => b.IsOverSubscriptionPlan)
                     .HasDefaultValueSql("0");

--- a/api/Migrations/DB/20220606083649_IsDeletedEmailUniqueIndex.Designer.cs
+++ b/api/Migrations/DB/20220606083649_IsDeletedEmailUniqueIndex.Designer.cs
@@ -3,14 +3,16 @@ using System;
 using Homo.AuthApi;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace IotApi.Migrations.DB
 {
     [DbContext(typeof(DBContext))]
-    partial class DBContextModelSnapshot : ModelSnapshot
+    [Migration("20220606083649_IsDeletedEmailUniqueIndex")]
+    partial class IsDeletedEmailUniqueIndex
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/api/Migrations/DB/20220606083649_IsDeletedEmailUniqueIndex.cs
+++ b/api/Migrations/DB/20220606083649_IsDeletedEmailUniqueIndex.cs
@@ -1,0 +1,33 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace IotApi.Migrations.DB
+{
+    public partial class IsDeletedEmailUniqueIndex : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_User_Email",
+                table: "User");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_User_Email_DeletedAt",
+                table: "User",
+                columns: new[] { "Email", "DeletedAt" },
+                unique: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_User_Email_DeletedAt",
+                table: "User");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_User_Email",
+                table: "User",
+                column: "Email",
+                unique: true);
+        }
+    }
+}


### PR DESCRIPTION
# 修改內容

- as title

# 修改專案

- API

# 測試網址和方式

- 把某個特定的使用者刪除後 在 DB.User.DeletedAt 加上 NOW()
- 在重新註冊一個使用者, 在 Email 驗證看是否還會出現重複的 Email 

# Reviewers

@LiangYingC @vickychou99 
