### PR TITLE
fix: 修正 device 列表 device pin 空白

### DIFF
--- a/dashboard/src/components/pins/pins.tsx
+++ b/dashboard/src/components/pins/pins.tsx
@@ -26,7 +26,7 @@ const Pins = (props: { deviceId: number; isEditMode: boolean }) => {
                 (item: PinItem) => item.deviceId === Number(deviceId)
             ) || [];
         setDevicePins(devicePins || null);
-        if (devicePinsFromStore !== null) {
+        if (isPinsGetted) {
             return;
         }
         getDevicePinsApi();


### PR DESCRIPTION


# 修改內容

- 每一次到 pins.tsx 都去拿資料避免在別的地方只拿到部分資料這邊就會留空

# 修改專案

- Dashboard F2E

# 測試網址和方式

- http://localhost:3000/  dashboard 頁面拿部分 device pins 
- http://localhost:3000/dashboard/devices 檢查是否所有 device pins 都有顯示

# Reviewers

@LiangYingC @vickychou99 
