### PR TITLE
Hotfix/fix switch device pin bug

### DIFF
--- a/dashboard/src/components/dashboard-monitor/switch-monitor/switch-monitor.tsx
+++ b/dashboard/src/components/dashboard-monitor/switch-monitor/switch-monitor.tsx
@@ -12,6 +12,7 @@ const SwitchMonitor = (props: { deviceId: number; pin: string }) => {
 
     const [devicePin, setDevicePin] = useState<PinItem | null>(null);
     const [value, setValue] = useState(0);
+    const [isFirstTimeGetPinValue, setIsFirstTimeGetPinValue] = useState(true);
 
     const { updateDeviceSwitchPinApi } = useUpdateDeviceSwitchPinApi({
         deviceId,
@@ -34,7 +35,11 @@ const SwitchMonitor = (props: { deviceId: number; pin: string }) => {
     }, []);
 
     useEffect(() => {
+        if (isFirstTimeGetPinValue) {
+            return;
+        }
         updateDeviceSwitchPinApi();
+        // eslint-disable-next-line
     }, [value]);
 
     useEffect(() => {
@@ -43,6 +48,7 @@ const SwitchMonitor = (props: { deviceId: number; pin: string }) => {
         }
         setDevicePin(responseOfGetDevicePin as PinItem);
         setValue(responseOfGetDevicePin.value || 0);
+        setIsFirstTimeGetPinValue(false); // 避免從其他裝置改狀態, 這邊一拿到新狀態發現不一樣就打 updateDeviceSwitchPinApi
     }, [responseOfGetDevicePin]);
 
     return (


### PR DESCRIPTION
# 修改內容

- #827 
- 修正 switch monitor 第一次拿到值的時候不去打 patch switch state 的 api, 有可能是使用這在其他裝置修改 switch state, 這時後第一次拿到值的時候會再去打一次 patch switch state

# 修改專案

- Dashboard F2E

# 測試網址和方式

- 測試一下修改狀態看是否正常打 PATCH API 
- 剩下的到測試機
  - 先透過電腦到 Dashboard 頁面取得所有 pin 資料
  - 透過手機或是其他裝置把剛剛其中一個 switch 資料做修改
  - 在回到電腦從 Dashboard -> 切到 oAuthClient List page -> 切回 Dashboard 看一下是否會打 Patch Device Switch Pin API 

# Reviewers
@LiangYingC @vickychou99 
