### PR TITLE
feat: 修正一進 Device 列表頁就打 Patch API

### DIFF
--- a/dashboard/src/components/pin/pin.tsx
+++ b/dashboard/src/components/pin/pin.tsx
@@ -52,16 +52,16 @@ const Pin = (props: { pinItem: PinItem; isEditMode: boolean }) => {
     };
 
     useEffect(() => {
+        // 完成 setValue 再執行 setIsInitialized true
+        if (!isInitialized && pinItem.value === value) {
+            setIsInitialized(true);
+        }
         if (!isInitialized || value === undefined || !isSwitch) {
             return;
         }
         updateDeviceSwitchPinApi();
         // eslint-disable-next-line
     }, [value, isSwitch]);
-
-    useEffect(() => {
-        setIsInitialized(true);
-    }, []);
 
     useEffect(() => {
         setName(nameFromProps || '');


### PR DESCRIPTION
# 修改內容

- Ref:#975
- 修改 setIsInitialized = true 的判斷， BUG 是因為 setValue 還沒執行完成時，就先執行 setIsInitialized 了，導致 value 更新後又打一次 patch api 

# 修改專案

- Dashboard F2E

# 測試網址和方式

- 確認進 Device 列表頁 / 明細頁，不會打 Patch API
- 確認 Switch 的狀態於 列頁表 / 明細頁，可以正常切換開關

# Reviewers

@miterfrants @LiangYingC 
