### PR TITLE
feat: 修正 cronjob 計時器

### DIFF
--- a/api/Services/AutoPaymentCronJobService.cs
+++ b/api/Services/AutoPaymentCronJobService.cs
@@ -21,7 +21,7 @@ namespace Homo.IotApi
         private readonly string _dbc;
 
         public AutoPaymentCronJob(IScheduleConfig<AutoPaymentCronJob> config, IServiceProvider serviceProvider, Microsoft.AspNetCore.Hosting.IWebHostEnvironment env, IOptions<AppSettings> appSettings)
-            : base(config.CronExpression, config.TimeZoneInfo, serviceProvider)
+            : base(config.CronExpression, config.TimeZoneInfo, serviceProvider, appSettings, "AutoPaymentCronJob", env)
         {
             _envName = env.EnvironmentName;
             _dbc = appSettings.Value.Secrets.DBConnectionString;

--- a/api/Services/ClearExpiredDevicePinSensorDataCronJobService.cs
+++ b/api/Services/ClearExpiredDevicePinSensorDataCronJobService.cs
@@ -19,7 +19,7 @@ namespace Homo.IotApi
         private readonly string _dbc;
 
         public ClearExpiredDevicePinSensorDataCronJobService(IScheduleConfig<ClearExpiredDevicePinSensorDataCronJobService> config, IServiceProvider serviceProvider, Microsoft.AspNetCore.Hosting.IWebHostEnvironment env, IOptions<AppSettings> appSettings)
-            : base(config.CronExpression, config.TimeZoneInfo, serviceProvider)
+            : base(config.CronExpression, config.TimeZoneInfo, serviceProvider, appSettings, "ClearExpiredDevicePinSensorDataCronJobService", env)
         {
             _envName = env.EnvironmentName;
             _dbc = appSettings.Value.Secrets.DBConnectionString;

--- a/api/Services/CronJobService.cs
+++ b/api/Services/CronJobService.cs
@@ -4,6 +4,8 @@ using System.Threading.Tasks;
 using Cronos;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+using Homo.AuthApi;
 
 namespace Homo.IotApi
 {
@@ -13,12 +15,24 @@ namespace Homo.IotApi
         private readonly CronExpression _expression;
         private readonly TimeZoneInfo _timeZoneInfo;
         protected readonly IServiceProvider _serviceProvider;
+        private readonly string _systemEmail;
+        private readonly string _adminEmail;
+        private readonly string _sendGridApiKey;
+        private readonly string _cronJobName;
+        private readonly string _envName;
 
-        protected CronJobService(string cronExpression, TimeZoneInfo timeZoneInfo, IServiceProvider serviceProvider)
+
+        protected CronJobService(string cronExpression, TimeZoneInfo timeZoneInfo, IServiceProvider serviceProvider, IOptions<AppSettings> optionAppSettings, string cronJobName, Microsoft.AspNetCore.Hosting.IWebHostEnvironment env)
         {
             _expression = CronExpression.Parse(cronExpression);
             _timeZoneInfo = timeZoneInfo;
             _serviceProvider = serviceProvider;
+            _systemEmail = optionAppSettings.Value.Common.SystemEmail;
+            _adminEmail = optionAppSettings.Value.Common.AdminEmail;
+            _sendGridApiKey = optionAppSettings.Value.Secrets.SendGridApiKey;
+            _cronJobName = cronJobName;
+            _envName = env.EnvironmentName;
+
         }
 
         public virtual async Task StartAsync(CancellationToken cancellationToken)
@@ -29,33 +43,36 @@ namespace Homo.IotApi
         protected virtual async Task ScheduleJob(CancellationToken cancellationToken)
         {
             var next = _expression.GetNextOccurrence(DateTimeOffset.Now, _timeZoneInfo);
-            if (next.HasValue)
+            if (!next.HasValue)
             {
-                var delay = next.Value - DateTimeOffset.Now;
-                if (delay.TotalMilliseconds <= 0)   // prevent non-positive values from being passed into Timer
-                {
-                    await ScheduleJob(cancellationToken);
-                }
-                else
-                {
-                    _timer = new System.Timers.Timer(delay.TotalMilliseconds);
+                sendEmailToAdmin(_cronJobName, "Get Next Occurrence error.");
+                return;
+            }
 
-                    _timer.Elapsed += async (sender, args) =>
+            var delay = next.Value - DateTimeOffset.Now;
+            if (delay.TotalMilliseconds <= 0)   // prevent non-positive values from being passed into Timer
+            {
+                sendEmailToAdmin(_cronJobName, "delay.TotalMilliseconds.");
+                await ScheduleJob(cancellationToken);
+            }
+            else
+            {
+                _timer = new System.Timers.Timer(delay.TotalMilliseconds);
+                _timer.Elapsed += async (sender, args) =>
+                {
+                    _timer.Dispose();  // reset and dispose timer
+                    _timer = null;
+
+                    if (!cancellationToken.IsCancellationRequested)
                     {
-                        _timer.Dispose();  // reset and dispose timer
-                        _timer = null;
+                        await DoWork(cancellationToken);
+                    }
 
-                        if (!cancellationToken.IsCancellationRequested)
-                        {
-                            await DoWork(cancellationToken);
-                        }
-
-                        if (!cancellationToken.IsCancellationRequested)
-                        {
-                            await ScheduleJob(cancellationToken);    // reschedule next
-                        }
-                    };
-                }
+                    if (!cancellationToken.IsCancellationRequested)
+                    {
+                        await ScheduleJob(cancellationToken);    // reschedule next
+                    }
+                };
                 _timer.Start();
             }
             await Task.CompletedTask;
@@ -76,6 +93,18 @@ namespace Homo.IotApi
         {
             _timer?.Dispose();
         }
+
+        public virtual async Task sendEmailToAdmin(string serviceName, string errorMessage)
+        {
+            await MailHelper.Send(MailProvider.SEND_GRID, new MailTemplate()
+            {
+                Subject = _envName + " CronJobs 發生錯誤: " + serviceName,
+                Content = errorMessage
+            }, _systemEmail, _adminEmail, _sendGridApiKey);
+
+        }
+
+
     }
 
     public interface IScheduleConfig<T>

--- a/api/Services/CronJobService.cs
+++ b/api/Services/CronJobService.cs
@@ -52,7 +52,10 @@ namespace Homo.IotApi
             var delay = next.Value - DateTimeOffset.Now;
             if (delay.TotalMilliseconds <= 0)   // prevent non-positive values from being passed into Timer
             {
-                sendEmailToAdmin(_cronJobName, "delay.TotalMilliseconds.");
+                if (!cancellationToken.IsCancellationRequested)
+                {
+                    await DoWork(cancellationToken);
+                }
                 await ScheduleJob(cancellationToken);
             }
             else
@@ -73,8 +76,10 @@ namespace Homo.IotApi
                         await ScheduleJob(cancellationToken);    // reschedule next
                     }
                 };
-                _timer.Start();
             }
+
+            _timer.Start();
+
             await Task.CompletedTask;
         }
 

--- a/api/Services/CronJobService.cs
+++ b/api/Services/CronJobService.cs
@@ -76,9 +76,9 @@ namespace Homo.IotApi
                         await ScheduleJob(cancellationToken);    // reschedule next
                     }
                 };
-            }
 
-            _timer.Start();
+                _timer.Start();
+            }
 
             await Task.CompletedTask;
         }

--- a/api/Services/CronJobService.cs
+++ b/api/Services/CronJobService.cs
@@ -36,22 +36,26 @@ namespace Homo.IotApi
                 {
                     await ScheduleJob(cancellationToken);
                 }
-                _timer = new System.Timers.Timer(delay.TotalMilliseconds);
-                _timer.Elapsed += async (sender, args) =>
+                else
                 {
-                    _timer.Dispose();  // reset and dispose timer
-                    _timer = null;
+                    _timer = new System.Timers.Timer(delay.TotalMilliseconds);
 
-                    if (!cancellationToken.IsCancellationRequested)
+                    _timer.Elapsed += async (sender, args) =>
                     {
-                        await DoWork(cancellationToken);
-                    }
+                        _timer.Dispose();  // reset and dispose timer
+                        _timer = null;
 
-                    if (!cancellationToken.IsCancellationRequested)
-                    {
-                        await ScheduleJob(cancellationToken);    // reschedule next
-                    }
-                };
+                        if (!cancellationToken.IsCancellationRequested)
+                        {
+                            await DoWork(cancellationToken);
+                        }
+
+                        if (!cancellationToken.IsCancellationRequested)
+                        {
+                            await ScheduleJob(cancellationToken);    // reschedule next
+                        }
+                    };
+                }
                 _timer.Start();
             }
             await Task.CompletedTask;

--- a/api/Services/DeviceActivityLogCronJobService.cs
+++ b/api/Services/DeviceActivityLogCronJobService.cs
@@ -13,7 +13,7 @@ namespace Homo.IotApi
         private readonly string _dbc;
 
         public DeviceActivityLogCronJobService(IScheduleConfig<DeviceActivityLogCronJobService> config, IServiceProvider serviceProvider, Microsoft.AspNetCore.Hosting.IWebHostEnvironment env, IOptions<AppSettings> appSettings)
-            : base(config.CronExpression, config.TimeZoneInfo, serviceProvider)
+            : base(config.CronExpression, config.TimeZoneInfo, serviceProvider, appSettings, "DeviceActivityLogCronJobService", env)
         {
             _envName = env.EnvironmentName;
             _dbc = appSettings.Value.Secrets.DBConnectionString;

--- a/api/Services/SendOverPlanNotificationCronJobService.cs
+++ b/api/Services/SendOverPlanNotificationCronJobService.cs
@@ -22,7 +22,8 @@ namespace Homo.IotApi
 
         private readonly string _staticPath;
 
-        public SendOverPlanNotificationCronJobService(IScheduleConfig<SendOverPlanNotificationCronJobService> config, IServiceProvider serviceProvider, Microsoft.AspNetCore.Hosting.IWebHostEnvironment env, IOptions<AppSettings> appSettings, Homo.Api.CommonLocalizer commonLocalizer) : base(config.CronExpression, config.TimeZoneInfo, serviceProvider)
+        public SendOverPlanNotificationCronJobService(IScheduleConfig<SendOverPlanNotificationCronJobService> config, IServiceProvider serviceProvider, Microsoft.AspNetCore.Hosting.IWebHostEnvironment env, IOptions<AppSettings> appSettings, Homo.Api.CommonLocalizer commonLocalizer)
+        : base(config.CronExpression, config.TimeZoneInfo, serviceProvider, appSettings, "SendOverPlanNotificationCronJobService", env)
         {
             _commonLocalizer = commonLocalizer;
             _envName = env.EnvironmentName;

--- a/api/Services/TriggerLogCronJobService.cs
+++ b/api/Services/TriggerLogCronJobService.cs
@@ -16,7 +16,7 @@ namespace Homo.IotApi
         private readonly string _dbc;
 
         public ClearTriggerLogCronJob(IScheduleConfig<ClearTriggerLogCronJob> config, IServiceProvider serviceProvider, Microsoft.AspNetCore.Hosting.IWebHostEnvironment env, IOptions<AppSettings> appSettings)
-            : base(config.CronExpression, config.TimeZoneInfo, serviceProvider)
+            : base(config.CronExpression, config.TimeZoneInfo, serviceProvider, appSettings, "ClearTriggerLogCronJob", env)
         {
             _envName = env.EnvironmentName;
             _dbc = appSettings.Value.Secrets.DBConnectionString;


### PR DESCRIPTION
# Ref

- #1016 

# 發生原因

- 執行`new System.Timers.Timer(delay.TotalMilliseconds);` 時， `delay.TotalMilliseconds` 傳入負數而產生錯誤。
- cronjob 計時器可能因為時間校正的關係，而讓執行 cronjob 的時間小於 Now，因此 `delay.TotalMilliseconds` 小於 0
- 此時程式雖然會重新排程，但因原本的 Schedule Function 內算出來的 `delay.TotalMilliseconds` 依然是小於 0 ，因此產生 bug 。

# 修改內容

- 將執行計時器的程式改於 `delay.TotalMilliseconds > 0` 時執行即可。

# 修改專案

- API

# 測試網址和方式

- 確認 cronjob 正常運作

# Reviewers

@miterfrants @LiangYingC 
