### PR TITLE
feat: 延長檢查裝置下線的時間

### DIFF
--- a/api/Services/TimeoutOfflineDeviceService.cs
+++ b/api/Services/TimeoutOfflineDeviceService.cs
@@ -20,7 +20,7 @@ namespace Homo.IotApi
             CancellationToken cancellationToken = tokenSource.Token;
             var task = Task.Run(async () =>
             {
-                await Task.Delay(16000);
+                await Task.Delay(60 * 1000);
                 if (cancellationToken.IsCancellationRequested)
                 {
                     return;


### PR DESCRIPTION
# 修改內容

- as title
- #1019

# 修改專案

- API


# 測試網址和方式

- 透過 postman 打 `POST` `"{id}/online"` API
- 看 16 秒後是否有下線 (本來 reset timer 是 16 秒)，現在改成 60 秒

# Reviewers

@LiangYingC @vickychou99 
