### PR TITLE
fix: 修正已經刪除的 device 不要出現在 google smart home query 裏頭

### DIFF
--- a/api/Dataservices/DevicePinDataservice.cs
+++ b/api/Dataservices/DevicePinDataservice.cs
@@ -203,6 +203,7 @@ namespace Homo.IotApi
                 DeviceId = pin.DeviceId,
                 Device = device
             })
+            .Where(x => x.Device.DeletedAt == null)
             .ToList().GroupJoin(
                 dbContext.SensorLog,
                 pin => new { pin.DeviceId, pin.OwnerId, pin.Pin },


### PR DESCRIPTION
# 修改內容

- 已經刪除的裝置不要再顯示在 Google Smart Home 的 Device List

# 修改專案

- API


# 測試網址和方式

`{{endpoint}}/api/v1/google-smart-home` 

```
{
    "inputs": [
        {
            "intent": "action.devices.SYNC"
        }
    ],
    "requestId": "16080306685035390925"
}
```

# Reviewers

@LiangYingC @vickychou99 
