### PR TITLE
feat: 實作裝置拿開關的時候順便切成上線

### DIFF
--- a/api/Controllers/OauthController.cs
+++ b/api/Controllers/OauthController.cs
@@ -176,7 +176,8 @@ namespace Homo.IotApi
             string token = JWTHelper.GenerateToken(_jwtKey, 24 * 30 * 24 * 60, new
             {
                 pricingPlan = subscrioption?.PricingPlan,
-                Id = user.Id
+                Id = user.Id,
+                IsDevice = true
             }, null);
 
             return new

--- a/api/Homo.AuthApi/Models/DTOs/JwtExtraPayload.cs
+++ b/api/Homo.AuthApi/Models/DTOs/JwtExtraPayload.cs
@@ -19,6 +19,7 @@ namespace Homo.AuthApi
             public string PseudonymousAddress { get; set; }
             public string Phone { get; set; }
             public bool? IsOverSubscriptionPlan { get; set; }
+            public bool? IsDevice { get; set; }
         }
     }
 }


### PR DESCRIPTION


# 修改內容

- exchange-token-for-device api 多給一個 flag 讓 server 知道這個 token 是否來自於 Device 如果是的話在拿 switch states 的時候就順便把裝置切成上限，讓 Device 可以少打一個 API 速度可以更快一點

# 修改專案

- API

# 測試網址和方式

- 用後台取得 switch 應該不會變成上線
- 用 `oauth/exchange-token-for-device` `POST` 取得 token 再拿 switch states 時裝置應該會被切為上線


# Reviewers

@LiangYingC @vickychou99 
