### PR TITLE
fix: 修正選單讀取群組資料

### DIFF
--- a/dashboard/src/app.tsx
+++ b/dashboard/src/app.tsx
@@ -118,21 +118,15 @@ const App = () => {
         getDeviceModesApi();
         getProtocols();
 
-        if (isGroupUser && groupIds.length > 0) {
-            getGroupNames();
-        }
         // eslint-disable-next-line
     }, []);
 
     useEffect(() => {
-        if (
-            pathname === '/dashboard/' ||
-            pathname.indexOf('/dashboard/groups/') === 0
-        ) {
+        if (isGroupUser && groupIds.length > 0) {
             getGroupNames();
         }
         // eslint-disable-next-line
-    }, [pathname]);
+    }, [isGroupUser, groupIds]);
 
     return token ? (
         <div className="dashboard" data-testid="Dashboard">


### PR DESCRIPTION
# 修改內容

- 群組選單修正 hook 執行的時間點

# 修改專案

- Dashboard F2E

# 測試網址和方式

- as title
- 登入後臺看一下是否有出現下圖有 `切換群組` 的選單但是沒有內容
<img width="249" alt="截圖 2023-07-22 上午11 55 50" src="https://github.com/miterfrants/itemhub/assets/2028693/2da4b265-f5da-4769-b324-77ba5cb80014">


# Reviewers

@LiangYingC @vickychou99 
