### PR TITLE
feat: implement scheduled clear expired pipeline execute logs

### DIFF
--- a/api/Services/ClearExpiredPipelineExecuteLogsCronJobService.cs
+++ b/api/Services/ClearExpiredPipelineExecuteLogsCronJobService.cs
@@ -1,0 +1,69 @@
+using System;
+using Microsoft.EntityFrameworkCore;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
+using Homo.Core.Helpers;
+
+namespace Homo.IotApi
+{
+    public class ClearExpiredPipelineExecuteLogsCronJobService : CronJobService
+    {
+        private readonly string _dbc;
+
+        public ClearExpiredPipelineExecuteLogsCronJobService(IScheduleConfig<ClearExpiredPipelineExecuteLogsCronJobService> config, IServiceProvider serviceProvider, Microsoft.AspNetCore.Hosting.IWebHostEnvironment env, IOptions<AppSettings> appSettings)
+            : base(config.CronExpression, config.TimeZoneInfo, serviceProvider, appSettings, "ClearExpiredPipelineExecuteLogsCronJobService", env)
+        {
+            _dbc = appSettings.Value.Secrets.DBConnectionString;
+        }
+
+        public override Task StartAsync(CancellationToken cancellationToken)
+        {
+            Console.WriteLine("ClearExpiredPipelineExecuteLogsCronJobService starts.");
+            return base.StartAsync(cancellationToken);
+        }
+
+        public override async Task<dynamic> DoWork(CancellationToken cancellationToken)
+        {
+            DbContextOptionsBuilder<IotDbContext> iotBuilder = new DbContextOptionsBuilder<IotDbContext>();
+            var serverVersion = new MySqlServerVersion(new Version(8, 0, 25));
+            iotBuilder.UseMySql(_dbc, serverVersion);
+            IotDbContext _iotDbContext = new IotDbContext(iotBuilder.Options);
+            string lockerKey = CryptographicHelper.GetSpecificLengthRandomString(12, true);
+            SystemConfigDataservice.OccupeLocker(_iotDbContext, SYSTEM_CONFIG.CLEAR_EXPIRED_PIN_DATA_LOCKER, lockerKey);
+
+            await Task.Delay(5000);
+            SystemConfig locker = SystemConfigDataservice.GetOne(_iotDbContext, SYSTEM_CONFIG.CLEAR_EXPIRED_PIN_DATA_LOCKER);
+            if (locker.Value != lockerKey)
+            {
+                return Task.CompletedTask;
+            }
+
+            Task<dynamic> task = await recursiveDeleteExecutePipelineLogs(null);
+            return task;
+        }
+
+        public async Task<dynamic> recursiveDeleteExecutePipelineLogs(long? latestId)
+        {
+            DbContextOptionsBuilder<IotDbContext> iotBuilder = new DbContextOptionsBuilder<IotDbContext>();
+            var serverVersion = new MySqlServerVersion(new Version(8, 0, 25));
+            iotBuilder.UseMySql(_dbc, serverVersion);
+            IotDbContext _iotDbContext = new IotDbContext(iotBuilder.Options);
+            long? currentLatestId = PipelineExecuteLogDataservice.DeleteExpiredDataAndGetLatestItemId(_iotDbContext, 1, 500, latestId);
+            if (currentLatestId == null)
+            {
+                Task task = new Task<dynamic>(() => new { });
+                task.Start();
+                return task;
+            }
+            await Task.Delay(5 * 1000);
+            return recursiveDeleteExecutePipelineLogs(currentLatestId);
+        }
+
+        public override Task StopAsync(CancellationToken cancellationToken)
+        {
+            Console.WriteLine("ClearExpiredPipelineExecuteLogsCronJobService is stopping.");
+            return base.StopAsync(cancellationToken);
+        }
+    }
+}

--- a/api/Startup.cs
+++ b/api/Startup.cs
@@ -171,6 +171,12 @@ namespace Homo.IotApi
                     c.CronExpression = @"0 0 * * *";
                 });
 
+            services.AddCronJob<ClearExpiredPipelineExecuteLogsCronJobService>(c =>
+                {
+                    c.TimeZoneInfo = TimeZoneInfo.Local;
+                    c.CronExpression = @"0 0 * * *";
+                });
+
             services.AddSwaggerGen(c =>
             {
                 c.EnableAnnotations();


### PR DESCRIPTION
# 修改內容

- 實作定期清除 pipeline execute log 

# 修改專案

- API

# 測試網址和方式

- 手動新增一筆 24h 前的 pipeline execute logs
- 手動新增一筆 10h 前的 pipeline execute logs
- 更改 startup.cs 裏頭執行清除 pipeline execute logs 的頻率
- 確認剛剛手動新增 24h 前的 pipeline execute logs 是否有被刪除，10h 的資料有被保留

# Reviewers

@LiangYingC @vickychou99 
